### PR TITLE
feat: layout 타입에 따른 사이즈 지정 (#2)

### DIFF
--- a/src/lib/foundation/Layout/index.tsx
+++ b/src/lib/foundation/Layout/index.tsx
@@ -1,0 +1,69 @@
+import { createGlobalStyle, styled } from 'styled-components';
+import { ILayout } from './type';
+import { LayoutContainer } from './styled';
+
+const GlobalStyles = createGlobalStyle`
+    html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+    // 적용시킬 css 입력
+    a{
+        text-decoration: none;
+        color: inherit;
+    }
+    *{
+        box-sizing: border-box;
+        
+    }
+`;
+
+const Layout = ({ children, size, system }: ILayout) => {
+  return (
+    <LayoutContainer size={size} system={system}>
+      <GlobalStyles />
+      {children}
+    </LayoutContainer>
+  );
+};
+
+export default Layout;

--- a/src/lib/foundation/Layout/index.tsx
+++ b/src/lib/foundation/Layout/index.tsx
@@ -1,66 +1,9 @@
-import { createGlobalStyle, styled } from 'styled-components';
 import { ILayout } from './type';
-import { LayoutContainer } from './styled';
+import { LayoutContainer } from './styles';
 
-const GlobalStyles = createGlobalStyle`
-    html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
-    // 적용시킬 css 입력
-    a{
-        text-decoration: none;
-        color: inherit;
-    }
-    *{
-        box-sizing: border-box;
-        
-    }
-`;
-
-const Layout = ({ children, size, system }: ILayout) => {
+const Layout = ({ children, size = 'tablet', system = 'android' }: ILayout) => {
   return (
     <LayoutContainer size={size} system={system}>
-      <GlobalStyles />
       {children}
     </LayoutContainer>
   );

--- a/src/lib/foundation/Layout/styled.tsx
+++ b/src/lib/foundation/Layout/styled.tsx
@@ -1,0 +1,10 @@
+import { styled } from 'styled-components';
+import { ILayout } from './type';
+
+export const LayoutContainer = styled.div<ILayout>`
+  margin: 24px;
+  height: ${(props) => props.size === 'tablet' && '640px'};
+  width: ${(props) => props.size === 'tablet' && '1024px'};
+  // 아래는 임시 border
+  border: 1px black solid;
+`;

--- a/src/lib/foundation/Layout/styles.ts
+++ b/src/lib/foundation/Layout/styles.ts
@@ -5,6 +5,4 @@ export const LayoutContainer = styled.div<ILayout>`
   margin: 24px;
   height: ${(props) => props.size === 'tablet' && '640px'};
   width: ${(props) => props.size === 'tablet' && '1024px'};
-  // 아래는 임시 border
-  border: 1px black solid;
 `;

--- a/src/lib/foundation/Layout/type.ts
+++ b/src/lib/foundation/Layout/type.ts
@@ -1,0 +1,8 @@
+type System = 'android' | 'ios';
+type TabletSize = 'tablet' | 'pc' | 'phone';
+
+export interface ILayout {
+  children: React.ReactNode;
+  system: System;
+  size: TabletSize;
+}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?
- 운영체제 및 사용기기에 따라 레이아웃 설정이 가능하도록 코드를 추가하였습니다.

## 기대 결과
- 레이아웃 태그 안에 컴포넌트를 배치하면 자동으로 레이아웃이 적용됩니다.

## 리뷰어에게 전달 사항
- App페이지 내에서 확인 해보실 수 있습니다. 
- children, system, size 모두 필수로 값을 주어야 합니다. (system='android' size='tablet')
- 현재 출시 버전이 tablet이기 때문에 현재 단일 사이즈밖에 없습니다. (height:640px, width:1024px)
- border 속성은 시각적 확인을 위해 임의로 값을 주었습니다.
- 피그마에는 columns와 gutter속성이 주어졌는데 그 값들은 생략하였습니다. (맞는지는 모르겠음)


## 스크린샷
[
![image](https://github.com/3-14-ketotop/3-14-ketotop/assets/102157884/b3c5406f-5cc9-40cd-983f-27b92a83b44e)
](url)

## 관련 이슈 번호

close : #2 
