### PR TITLE
feat: PopupMenu 컴포넌트 기능개발 (#10)

### DIFF
--- a/src/lib/components/PopupMenu/PopupMenuList/index.tsx
+++ b/src/lib/components/PopupMenu/PopupMenuList/index.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react';
 import { ListProps } from './type';
-import { PopupMenuListStyles } from './styles';
+import * as St from './styles';
 
 const PopupMenuList: FC<ListProps> = ({ itemList }) => {
-  return itemList.map((item, index) => <PopupMenuListStyles key={index}>{item}</PopupMenuListStyles>);
+  return itemList.map((item, index) => <St.PopupMenuListStyles key={index}>{item}</St.PopupMenuListStyles>);
 };
 
 export default PopupMenuList;

--- a/src/lib/components/PopupMenu/PopupMenuList/index.tsx
+++ b/src/lib/components/PopupMenu/PopupMenuList/index.tsx
@@ -1,0 +1,9 @@
+import { FC } from 'react';
+import { ListProps } from './type';
+import { PopupMenuListStyles } from './styles';
+
+const PopupMenuList: FC<ListProps> = ({ itemList }) => {
+  return itemList.map((item, index) => <PopupMenuListStyles key={index}>{item}</PopupMenuListStyles>);
+};
+
+export default PopupMenuList;

--- a/src/lib/components/PopupMenu/PopupMenuList/styles.ts
+++ b/src/lib/components/PopupMenu/PopupMenuList/styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const PopupMenuListStyles = styled.div`
+  /** Layout */
+  display: inline-flex;
+  padding: 16px 24px;
+  align-items: center;
+  gap: 10px;
+  min-width: 228px;
+  cursor: pointer;
+`;

--- a/src/lib/components/PopupMenu/PopupMenuList/type.ts
+++ b/src/lib/components/PopupMenu/PopupMenuList/type.ts
@@ -1,3 +1,3 @@
 export interface ListProps {
-  itemList: string[];
+  itemList: [string?] | [string?, string?] | [string?, string?, string?] | [string?, string?, string?, string?];
 }

--- a/src/lib/components/PopupMenu/PopupMenuList/type.ts
+++ b/src/lib/components/PopupMenu/PopupMenuList/type.ts
@@ -1,0 +1,3 @@
+export interface ListProps {
+  itemList: string[];
+}

--- a/src/lib/components/PopupMenu/index.tsx
+++ b/src/lib/components/PopupMenu/index.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { PopupMenuProps } from './type';
+import { PopupMenuStyles } from './styles';
+import PopupMenuList from './PopupMenuList';
+
+const PopupMenuDisplay: FC<PopupMenuProps> = ({ header, itemList }) => {
+  return (
+    <>
+      <PopupMenuStyles header={header} itemList={itemList}>
+        <PopupMenuList itemList={itemList} />
+      </PopupMenuStyles>
+    </>
+  );
+};
+
+export default PopupMenuDisplay;

--- a/src/lib/components/PopupMenu/index.tsx
+++ b/src/lib/components/PopupMenu/index.tsx
@@ -1,14 +1,14 @@
 import { FC } from 'react';
 import { PopupMenuProps } from './type';
-import { PopupMenuStyles } from './styles';
+import * as St from './styles';
 import PopupMenuList from './PopupMenuList';
 
-const PopupMenuDisplay: FC<PopupMenuProps> = ({ header, itemList }) => {
+const PopupMenuDisplay: FC<PopupMenuProps> = ({ headerType, itemList }) => {
   return (
     <>
-      <PopupMenuStyles header={header} itemList={itemList}>
+      <St.PopupMenuStyles headerType={headerType} itemList={itemList}>
         <PopupMenuList itemList={itemList} />
-      </PopupMenuStyles>
+      </St.PopupMenuStyles>
     </>
   );
 };

--- a/src/lib/components/PopupMenu/styles.ts
+++ b/src/lib/components/PopupMenu/styles.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { PopupMenuProps } from './type';
+
+export const PopupMenuStyles = styled.section<PopupMenuProps>`
+  /** Style */
+  display: inline-flex;
+  flex-direction: column;
+  border-radius: 10px;
+  border: 1px solid var(--Line_200);
+  background: var(--Bg_Wh);
+  /** Shadow */
+  box-shadow: 0px 0px 8px 2px var(--Shadow);
+
+  /** 조건부 렌더링 */
+  ${(props) => {
+    switch (props.header) {
+      case 'NavigationBar':
+        return 'margin-top: 6px;';
+      case 'AppBar':
+        return 'margin-top: 8px;';
+      default:
+        return '';
+    }
+  }}
+`;

--- a/src/lib/components/PopupMenu/styles.ts
+++ b/src/lib/components/PopupMenu/styles.ts
@@ -13,7 +13,7 @@ export const PopupMenuStyles = styled.section<PopupMenuProps>`
 
   /** 조건부 렌더링 */
   ${(props) => {
-    switch (props.header) {
+    switch (props.headerType) {
       case 'NavigationBar':
         return 'margin-top: 6px;';
       case 'AppBar':

--- a/src/lib/components/PopupMenu/type.ts
+++ b/src/lib/components/PopupMenu/type.ts
@@ -1,5 +1,5 @@
 export interface PopupMenuProps {
   /** 상단 컴포넌트 종류 */
-  header?: 'NavigationBar' | 'AppBar';
+  headerType?: 'NavigationBar' | 'AppBar';
   itemList: [string?] | [string?, string?] | [string?, string?, string?] | [string?, string?, string?, string?];
 }

--- a/src/lib/components/PopupMenu/type.ts
+++ b/src/lib/components/PopupMenu/type.ts
@@ -1,5 +1,5 @@
 export interface PopupMenuProps {
   /** 상단 컴포넌트 종류 */
   header?: 'NavigationBar' | 'AppBar';
-  itemList: string[];
+  itemList: [string?] | [string?, string?] | [string?, string?, string?] | [string?, string?, string?, string?];
 }

--- a/src/lib/components/PopupMenu/type.ts
+++ b/src/lib/components/PopupMenu/type.ts
@@ -1,0 +1,5 @@
+export interface PopupMenuProps {
+  /** 상단 컴포넌트 종류 */
+  header?: 'NavigationBar' | 'AppBar';
+  itemList: string[];
+}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- PopupMenu 를 사용자가 사용할수 있도록 만들기 위해 개발하였습니다.

## 기대 결과

- header 프롭스로 NavigationBar 혹은 AppBar 를 넣어줌으로서, 상단에 어떤 컴포넌트가 들어가는지 정해줍니다.
- itemList 로, PopupMenu 에 들어갈 텍스트를 배열로 만들어 정해줍니다. ( 최대 4개의 항목이 들어가도록 타입을 설정해 두었습니다. )

## 리뷰어에게 전달 사항

- 확인부탁드립니다~!

## 스크린샷
<img width="326" alt="팝업" src="https://github.com/3-14-ketotop/3-14-ketotop/assets/57481378/80254987-df73-4442-b6bd-cd411257029a">

## 관련 이슈 번호

close : #10 
