### PR TITLE
feat: Thumbnails 컴포넌트 개발 (#21)

### DIFF
--- a/src/lib/components/Thumbnails/Image/index.tsx
+++ b/src/lib/components/Thumbnails/Image/index.tsx
@@ -1,29 +1,29 @@
 import Icon from '@lib/foundation/Icon';
-import * as ST from '../styles';
+import * as St from '../styles';
 import { IImage } from '../type';
 
 const ImageThumbnails = ({ state = 'normal', type = 'image', src }: IImage) => {
   return (
-    <ST.ThumbnailsContainer src={src} state={state}>
-      <ST.BackgroundColor state={state} />
+    <St.ThumbnailsContainer src={src} state={state}>
+      <St.BackgroundColor state={state} />
 
       {state === 'delete' && (
-        <ST.DeleteState>
+        <St.DeleteState>
           <Icon name='thumbnails_deletecircle' />
-        </ST.DeleteState>
+        </St.DeleteState>
       )}
       {state === 'select' && (
-        <ST.SelectState>
+        <St.SelectState>
           <Icon name='thumbnails_checkcircle' />
-        </ST.SelectState>
+        </St.SelectState>
       )}
       {state === 'error' && (
-        <ST.ErrorState>
+        <St.ErrorState>
           <Icon name='thumbnails_errorcircle' />
           <p>원본 파일 삭제됨</p>
-        </ST.ErrorState>
+        </St.ErrorState>
       )}
-    </ST.ThumbnailsContainer>
+    </St.ThumbnailsContainer>
   );
 };
 

--- a/src/lib/components/Thumbnails/Image/index.tsx
+++ b/src/lib/components/Thumbnails/Image/index.tsx
@@ -1,0 +1,30 @@
+import Icon from '@lib/foundation/Icon';
+import * as ST from '../styles';
+import { IImage } from '../type';
+
+const ImageThumbnails = ({ state = 'normal', type = 'image', src }: IImage) => {
+  return (
+    <ST.ThumbnailsContainer src={src} state={state}>
+      <ST.BackgroundColor state={state} />
+
+      {state === 'delete' && (
+        <ST.DeleteState>
+          <Icon name='thumbnails_deletecircle' />
+        </ST.DeleteState>
+      )}
+      {state === 'select' && (
+        <ST.SelectState>
+          <Icon name='thumbnails_checkcircle' />
+        </ST.SelectState>
+      )}
+      {state === 'error' && (
+        <ST.ErrorState>
+          <Icon name='thumbnails_errorcircle' />
+          <p>원본 파일 삭제됨</p>
+        </ST.ErrorState>
+      )}
+    </ST.ThumbnailsContainer>
+  );
+};
+
+export default ImageThumbnails;

--- a/src/lib/components/Thumbnails/Image/index.tsx
+++ b/src/lib/components/Thumbnails/Image/index.tsx
@@ -2,9 +2,9 @@ import Icon from '@lib/foundation/Icon';
 import * as St from '../styles';
 import { IImage } from '../type';
 
-const ImageThumbnails = ({ state = 'normal', type = 'image', src }: IImage) => {
+const ImageThumbnail = ({ state = 'normal', type = 'image', src }: IImage) => {
   return (
-    <St.ThumbnailsContainer src={src} state={state}>
+    <St.ThumbnailContainer src={src} state={state}>
       <St.BackgroundColor state={state} />
 
       {state === 'delete' && (
@@ -23,8 +23,8 @@ const ImageThumbnails = ({ state = 'normal', type = 'image', src }: IImage) => {
           <p>원본 파일 삭제됨</p>
         </St.ErrorState>
       )}
-    </St.ThumbnailsContainer>
+    </St.ThumbnailContainer>
   );
 };
 
-export default ImageThumbnails;
+export default ImageThumbnail;

--- a/src/lib/components/Thumbnails/Video/index.tsx
+++ b/src/lib/components/Thumbnails/Video/index.tsx
@@ -3,7 +3,7 @@ import * as ST from '../styles';
 import { IVideo } from '../type';
 
 const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 0 }: IVideo) => {
-  const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000)).padStart(2, '0');
+  const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000));
   const runningTimeSec = (runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0')) || '00';
 
   return (

--- a/src/lib/components/Thumbnails/Video/index.tsx
+++ b/src/lib/components/Thumbnails/Video/index.tsx
@@ -2,12 +2,12 @@ import Icon from '@lib/foundation/Icon';
 import * as St from '../styles';
 import { IVideo } from '../type';
 
-const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 0 }: IVideo) => {
+const VideoThumbnail = ({ state = 'normal', type = 'video', src, runningtime = 0 }: IVideo) => {
   const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000));
   const runningTimeSec = (runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0')) || '00';
 
   return (
-    <St.ThumbnailsContainer src={src} state={state}>
+    <St.ThumbnailContainer src={src} state={state}>
       <St.VideoRunningTime>
         {runningTimeMin}:{runningTimeSec}
       </St.VideoRunningTime>
@@ -34,8 +34,8 @@ const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 
           <Icon name='thumbnails_playcircle' />
         </St.PlayState>
       )}
-    </St.ThumbnailsContainer>
+    </St.ThumbnailContainer>
   );
 };
 
-export default VideoThumbnails;
+export default VideoThumbnail;

--- a/src/lib/components/Thumbnails/Video/index.tsx
+++ b/src/lib/components/Thumbnails/Video/index.tsx
@@ -1,0 +1,41 @@
+import Icon from '@lib/foundation/Icon';
+import * as ST from '../styles';
+import { IVideo } from '../type';
+
+const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 0 }: IVideo) => {
+  const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000)).padStart(2, '0');
+  const runningTimeSec = (runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0')) || '00';
+
+  return (
+    <ST.ThumbnailsContainer src={src} state={state}>
+      <ST.VideoRunningTime>
+        {runningTimeMin}:{runningTimeSec}
+      </ST.VideoRunningTime>
+      <ST.BackgroundColor state={state} />
+
+      {state === 'delete' && (
+        <ST.DeleteState>
+          <Icon name='thumbnails_deletecircle' />
+        </ST.DeleteState>
+      )}
+      {state === 'select' && (
+        <ST.SelectState>
+          <Icon name='thumbnails_checkcircle' />
+        </ST.SelectState>
+      )}
+      {state === 'error' && (
+        <ST.ErrorState>
+          <Icon name='thumbnails_errorcircle' />
+          <p>원본 파일 삭제됨</p>
+        </ST.ErrorState>
+      )}
+      {state === 'video_play' && (
+        <ST.PlayState>
+          <Icon name='thumbnails_playcircle' />
+        </ST.PlayState>
+      )}
+    </ST.ThumbnailsContainer>
+  );
+};
+
+export default VideoThumbnails;

--- a/src/lib/components/Thumbnails/Video/index.tsx
+++ b/src/lib/components/Thumbnails/Video/index.tsx
@@ -1,5 +1,5 @@
 import Icon from '@lib/foundation/Icon';
-import * as ST from '../styles';
+import * as St from '../styles';
 import { IVideo } from '../type';
 
 const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 0 }: IVideo) => {
@@ -7,34 +7,34 @@ const VideoThumbnails = ({ state = 'normal', type = 'video', src, runningtime = 
   const runningTimeSec = (runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0')) || '00';
 
   return (
-    <ST.ThumbnailsContainer src={src} state={state}>
-      <ST.VideoRunningTime>
+    <St.ThumbnailsContainer src={src} state={state}>
+      <St.VideoRunningTime>
         {runningTimeMin}:{runningTimeSec}
-      </ST.VideoRunningTime>
-      <ST.BackgroundColor state={state} />
+      </St.VideoRunningTime>
+      <St.BackgroundColor state={state} />
 
       {state === 'delete' && (
-        <ST.DeleteState>
+        <St.DeleteState>
           <Icon name='thumbnails_deletecircle' />
-        </ST.DeleteState>
+        </St.DeleteState>
       )}
       {state === 'select' && (
-        <ST.SelectState>
+        <St.SelectState>
           <Icon name='thumbnails_checkcircle' />
-        </ST.SelectState>
+        </St.SelectState>
       )}
       {state === 'error' && (
-        <ST.ErrorState>
+        <St.ErrorState>
           <Icon name='thumbnails_errorcircle' />
           <p>원본 파일 삭제됨</p>
-        </ST.ErrorState>
+        </St.ErrorState>
       )}
       {state === 'video_play' && (
-        <ST.PlayState>
+        <St.PlayState>
           <Icon name='thumbnails_playcircle' />
-        </ST.PlayState>
+        </St.PlayState>
       )}
-    </ST.ThumbnailsContainer>
+    </St.ThumbnailsContainer>
   );
 };
 

--- a/src/lib/components/Thumbnails/index.tsx
+++ b/src/lib/components/Thumbnails/index.tsx
@@ -1,4 +1,4 @@
-import ImageThumbnails from './Image';
-import VideoThumbnails from './Video';
+import ImageThumbnail from './Image';
+import VideoThumbnail from './Video';
 
-export { ImageThumbnails, VideoThumbnails };
+export { ImageThumbnail, VideoThumbnail };

--- a/src/lib/components/Thumbnails/index.tsx
+++ b/src/lib/components/Thumbnails/index.tsx
@@ -1,31 +1,4 @@
-import Icon from '@lib/foundation/Icon';
-import * as ST from './styles';
-import { IThumbnails } from './type';
+import ImageThumbnails from './Image';
+import VideoThumbnails from './Video';
 
-const Thumbnails = ({ state, type, src, runningtime }: IThumbnails) => {
-  const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000)).padStart(2, '0');
-  const runningTimeSec = runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0');
-
-  return (
-    <ST.ThumbnailsContainer src={src}>
-      {/* <ST.ThumbnailImage src={src} /> */}
-      <ST.VideoRunningTime>
-        {runningTimeMin}:{runningTimeSec}
-      </ST.VideoRunningTime>
-      <ST.BackgroundColor state={state} />
-      <ST.StateIcon state={state}>
-        {state === 'delete' && <Icon name='thumbnails_deletecircle' />}
-        {state === 'select' && <Icon name='thumbnails_checkcircle' />}
-        {state === 'video_play' && <Icon name='thumbnails_playcircle' />}
-        {state === 'error' && (
-          <div>
-            <Icon name='thumbnails_errorcircle' />
-            <p>원본 파일 삭제됨</p>
-          </div>
-        )}
-      </ST.StateIcon>
-    </ST.ThumbnailsContainer>
-  );
-};
-
-export default Thumbnails;
+export { ImageThumbnails, VideoThumbnails };

--- a/src/lib/components/Thumbnails/index.tsx
+++ b/src/lib/components/Thumbnails/index.tsx
@@ -1,0 +1,31 @@
+import Icon from '@lib/foundation/Icon';
+import * as ST from './styles';
+import { IThumbnails } from './type';
+
+const Thumbnails = ({ state, type, src, runningtime }: IThumbnails) => {
+  const runningTimeMin = runningtime && String(Math.floor(runningtime / 60000)).padStart(2, '0');
+  const runningTimeSec = runningtime && String(Math.floor((runningtime / 1000) % 60)).padStart(2, '0');
+
+  return (
+    <ST.ThumbnailsContainer src={src}>
+      {/* <ST.ThumbnailImage src={src} /> */}
+      <ST.VideoRunningTime>
+        {runningTimeMin}:{runningTimeSec}
+      </ST.VideoRunningTime>
+      <ST.BackgroundColor state={state}></ST.BackgroundColor>
+      <ST.StateIcon>
+        {state === 'delete' && <Icon name='thumbnails_deletecircle' />}
+        {state === 'select' && <Icon name='thumbnails_checkcircle' />}
+        {state === 'video_play' && <Icon name='thumbnails_playcircle' />}
+        {state === 'error' && (
+          <div>
+            <Icon name='thumbnails_errorcircle' />
+            <p>원본 파일 삭제됨</p>
+          </div>
+        )}
+      </ST.StateIcon>
+    </ST.ThumbnailsContainer>
+  );
+};
+
+export default Thumbnails;

--- a/src/lib/components/Thumbnails/index.tsx
+++ b/src/lib/components/Thumbnails/index.tsx
@@ -12,8 +12,8 @@ const Thumbnails = ({ state, type, src, runningtime }: IThumbnails) => {
       <ST.VideoRunningTime>
         {runningTimeMin}:{runningTimeSec}
       </ST.VideoRunningTime>
-      <ST.BackgroundColor state={state}></ST.BackgroundColor>
-      <ST.StateIcon>
+      <ST.BackgroundColor state={state} />
+      <ST.StateIcon state={state}>
         {state === 'delete' && <Icon name='thumbnails_deletecircle' />}
         {state === 'select' && <Icon name='thumbnails_checkcircle' />}
         {state === 'video_play' && <Icon name='thumbnails_playcircle' />}

--- a/src/lib/components/Thumbnails/styles.ts
+++ b/src/lib/components/Thumbnails/styles.ts
@@ -3,39 +3,13 @@ import { IThumbnails } from './type';
 
 export const ThumbnailsContainer = styled.div<IThumbnails>`
   position: relative;
-  background-color: yellow;
+
   width: 100px;
   height: 100px;
+
   border-radius: 4px;
   background-image: url(${(props) => props.src});
-
-  p {
-    position: absolute;
-    bottom: 8px;
-    color: var(--Bg_300);
-    font-size: 0.75rem;
-  }
-`;
-export const BackgroundColor = styled.div<IThumbnails>`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 4px;
-
-  opacity: 0.6;
-  /* state에 따른 backgorund 색상 변경 */
-  background-color: ${({ state }) => {
-    switch (state) {
-      case 'select':
-        return 'var(--Pri_500)';
-      case 'video_play':
-        return 'var(--Dim)';
-      case 'error':
-        return 'var(--Dim)';
-      default:
-        return '';
-    }
-  }};
+  background-size: cover;
 `;
 
 export const VideoRunningTime = styled.div`
@@ -51,9 +25,80 @@ export const VideoRunningTime = styled.div`
   height: 23px;
 
   border-radius: 4px;
+
   color: var(--Text_Wh);
   font-size: 0.75rem;
   background-color: rgba(40, 40, 40, 0.6);
 `;
-export const StateIcon = styled.div``;
-export const ThumbnailImage = styled.img``;
+
+export const BackgroundColor = styled.div<IThumbnails>`
+  position: absolute;
+
+  width: 100%;
+  height: 100%;
+
+  border-radius: 4px;
+  opacity: 0.6;
+
+  /* state에 따른 backgorund 색상 변경 */
+  background-color: ${({ state }) => {
+    switch (state) {
+      case 'select':
+        return 'var(--Pri_500)';
+      case 'video_play':
+        return 'var(--Dim)';
+      case 'error':
+        return 'var(--Dim)';
+      default:
+        return '';
+    }
+  }};
+
+  cursor: ${({ state }) => (state === 'video_play' ? 'pointer' : null)};
+`;
+
+export const StateIcon = styled.div<IThumbnails>`
+  position: absolute;
+  top: ${({ state }) => {
+    switch (state) {
+      case 'delete':
+        return '-12px';
+      case 'select':
+        return '50%';
+      case 'video_play':
+        return '50%';
+      case 'error':
+        return '50%';
+      default:
+        return '';
+    }
+  }};
+  left: ${({ state }) => {
+    switch (state) {
+      case 'select':
+        return '50%';
+      case 'video_play':
+        return '50%';
+      case 'error':
+        return '50%';
+      default:
+        return '';
+    }
+  }};
+  right: ${({ state }) => (state === 'delete' ? '-12px' : null)};
+  transform: ${({ state }) => (state === 'delete' ? null : 'translate(-50%, -50%)')};
+
+  cursor: ${({ state }) => (state === 'delete' || state === 'video_play' ? 'pointer' : null)};
+  background-color: aliceblue;
+  div {
+    background-color: yellow;
+    p {
+      width: 100%;
+      display: inline-block;
+      background-color: blue;
+    }
+  }
+  color: var(--Bg_300);
+  font-size: 0.75rem;
+  z-index: 99;
+`;

--- a/src/lib/components/Thumbnails/styles.ts
+++ b/src/lib/components/Thumbnails/styles.ts
@@ -1,15 +1,20 @@
 import styled from 'styled-components';
-import { IThumbnails } from './type';
+import { IImage, IVideo } from './type';
 
-export const ThumbnailsContainer = styled.div<IThumbnails>`
+export const ThumbnailsContainer = styled.div<IVideo | IImage>`
   position: relative;
 
   width: 100px;
   height: 100px;
 
+  margin: ${({ state }) => (state === 'delete' ? '10px 10px 0 0' : null)};
+
   border-radius: 4px;
   background-image: url(${(props) => props.src});
   background-size: cover;
+
+  color: var(--Bg_300);
+  font-size: 0.75rem;
 `;
 
 export const VideoRunningTime = styled.div`
@@ -31,7 +36,7 @@ export const VideoRunningTime = styled.div`
   background-color: rgba(40, 40, 40, 0.6);
 `;
 
-export const BackgroundColor = styled.div<IThumbnails>`
+export const BackgroundColor = styled.div<IVideo | IImage>`
   position: absolute;
 
   width: 100%;
@@ -57,48 +62,42 @@ export const BackgroundColor = styled.div<IThumbnails>`
   cursor: ${({ state }) => (state === 'video_play' ? 'pointer' : null)};
 `;
 
-export const StateIcon = styled.div<IThumbnails>`
+export const DeleteState = styled.div`
   position: absolute;
-  top: ${({ state }) => {
-    switch (state) {
-      case 'delete':
-        return '-12px';
-      case 'select':
-        return '50%';
-      case 'video_play':
-        return '50%';
-      case 'error':
-        return '50%';
-      default:
-        return '';
-    }
-  }};
-  left: ${({ state }) => {
-    switch (state) {
-      case 'select':
-        return '50%';
-      case 'video_play':
-        return '50%';
-      case 'error':
-        return '50%';
-      default:
-        return '';
-    }
-  }};
-  right: ${({ state }) => (state === 'delete' ? '-12px' : null)};
-  transform: ${({ state }) => (state === 'delete' ? null : 'translate(-50%, -50%)')};
-
-  cursor: ${({ state }) => (state === 'delete' || state === 'video_play' ? 'pointer' : null)};
-  background-color: aliceblue;
-  div {
-    background-color: yellow;
-    p {
-      width: 100%;
-      display: inline-block;
-      background-color: blue;
-    }
+  top: -12px;
+  right: -12px;
+  img {
+    cursor: pointer;
   }
-  color: var(--Bg_300);
-  font-size: 0.75rem;
-  z-index: 99;
+`;
+
+export const SelectState = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const ErrorState = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  p {
+    margin: 4px 0 0 0;
+  }
+`;
+
+export const PlayState = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  cursor: pointer;
 `;

--- a/src/lib/components/Thumbnails/styles.ts
+++ b/src/lib/components/Thumbnails/styles.ts
@@ -12,6 +12,7 @@ export const ThumbnailsContainer = styled.div<IVideo | IImage>`
   border-radius: 4px;
   background-image: url(${(props) => props.src});
   background-size: cover;
+  background-position: center;
 
   color: var(--Bg_300);
   font-size: 0.75rem;

--- a/src/lib/components/Thumbnails/styles.ts
+++ b/src/lib/components/Thumbnails/styles.ts
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import { IThumbnails } from './type';
+
+export const ThumbnailsContainer = styled.div<IThumbnails>`
+  position: relative;
+  background-color: yellow;
+  width: 100px;
+  height: 100px;
+  border-radius: 4px;
+  background-image: url(${(props) => props.src});
+
+  p {
+    position: absolute;
+    bottom: 8px;
+    color: var(--Bg_300);
+    font-size: 0.75rem;
+  }
+`;
+export const BackgroundColor = styled.div<IThumbnails>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+
+  opacity: 0.6;
+  /* state에 따른 backgorund 색상 변경 */
+  background-color: ${({ state }) => {
+    switch (state) {
+      case 'select':
+        return 'var(--Pri_500)';
+      case 'video_play':
+        return 'var(--Dim)';
+      case 'error':
+        return 'var(--Dim)';
+      default:
+        return '';
+    }
+  }};
+`;
+
+export const VideoRunningTime = styled.div`
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 46px;
+  height: 23px;
+
+  border-radius: 4px;
+  color: var(--Text_Wh);
+  font-size: 0.75rem;
+  background-color: rgba(40, 40, 40, 0.6);
+`;
+export const StateIcon = styled.div``;
+export const ThumbnailImage = styled.img``;

--- a/src/lib/components/Thumbnails/styles.ts
+++ b/src/lib/components/Thumbnails/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { IImage, IVideo } from './type';
 
-export const ThumbnailsContainer = styled.div<IVideo | IImage>`
+export const ThumbnailContainer = styled.div<IVideo | IImage>`
   position: relative;
 
   width: 100px;

--- a/src/lib/components/Thumbnails/type.ts
+++ b/src/lib/components/Thumbnails/type.ts
@@ -1,0 +1,22 @@
+export interface IThumbnails {
+  type?: 'video' | 'image';
+  src?: string;
+  state?: VideoState;
+  runningtime?: number;
+}
+
+type VideoState = 'normal' | 'delete' | 'select' | 'video_play' | 'error';
+
+/**
+export interface IVideo extends IThumbnails {
+  state?: VideoState;
+}
+
+export interface IImage extends IThumbnails {
+  state?: ImageState;
+}
+
+type VideoState = 'normal' | 'delete' | 'select' | 'video_play' | 'error';
+type ImageState = 'normal' | 'delete' | 'select' | 'error';
+
+ */

--- a/src/lib/components/Thumbnails/type.ts
+++ b/src/lib/components/Thumbnails/type.ts
@@ -1,22 +1,15 @@
-export interface IThumbnails {
-  type?: 'video' | 'image';
+export interface IVideo {
+  type?: 'video';
   src?: string;
   state?: VideoState;
   runningtime?: number;
 }
 
-type VideoState = 'normal' | 'delete' | 'select' | 'video_play' | 'error';
-
-/**
-export interface IVideo extends IThumbnails {
-  state?: VideoState;
-}
-
-export interface IImage extends IThumbnails {
+export interface IImage {
+  type?: 'image';
+  src?: string;
   state?: ImageState;
 }
 
 type VideoState = 'normal' | 'delete' | 'select' | 'video_play' | 'error';
 type ImageState = 'normal' | 'delete' | 'select' | 'error';
-
- */


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- 영상/이미지의 상태에 따라 썸네일을 나타낼 수 있도록 컴포넌트를 만들었습니다.

## 기대 결과

- 각 상태(normal, delete, select, error, (video_play))에 따라 썸네일 스타일을 변경할 수 있습니다.

## 리뷰어에게 전달 사항

- Image과 Video로 폴더를 분리하여 각 컴포넌트명이 구분됩니다.
- src는 필수 prop입니다.
- 비디오의 running time의 경우 millisecond를 기준으로 적용시켰습니다.
- 추후 중복되는 코드를 최대한 제거하는 리팩토링이 필요합니다.
- 다음과 같이 코드를 적용하시면 됩니다.
```tsx
ex)
<ImageThumbnails src={이미지주소} state='error' />
<VideoThumbnails src={이미지주소} state='normal' runningtime={65200} />
```

---

- 리뷰 답변 : prop전달 state=delete; prop전달 시 생기는 margin은 피그마 디자인을 기반으로 준 여백 값입니다. GUI디자인을 참고하면 이 delete 상태의 썸네일은 영상/이미지 파일 추가시에만 (ex)회원관리 페이지) 사용됩니다. 만약 이 delete 상태의 썸네일이 다른 state들과 동시에 사용된다면 여백으로 인해 썸네일 크기가 제 각각 달라 보기 좋지 않은 UI를 유발할 수 있으나 그럴만한 상황이 없다고 판단하여 최대한 주어진 시안과 같도록 제작한 점 공유 드립니다.

  - 기본 썸네일의 크기 (100*100)
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/6b735fcb-7df1-4930-be9f-623b9551dc38)
  - 삭제 썸네일의 크기 (109*108)
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/4d0592b1-450e-4295-8423-5bbc3b28f3a1)
  - 삭제 썸네일이 사용되는 회원관리 페이지
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/85b39212-6e33-432d-a55a-d4d36c100616)

## 스크린샷
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/17506295-158b-4507-9e2b-961cc7ce5e14)


## 관련 이슈 번호

close : #21 
