### PR TITLE
feat: NavigationBar 컴포넌트 개발 (#32)

### DIFF
--- a/src/lib/components/NavigationBar/Bottom/index.tsx
+++ b/src/lib/components/NavigationBar/Bottom/index.tsx
@@ -1,0 +1,55 @@
+import { IconStyles, TypographyStyles } from '@lib/foundation';
+import { INavBar } from '../type';
+import * as St from './style';
+
+const NavigationBarBottom = ({ page = 'home' }: INavBar) => {
+  return (
+    <St.NavBottomContainer>
+      <St.MenuList>
+        <St.Menu>
+          {page === 'home' ? (
+            <IconStyles name='appbar_home' extension='svg' />
+          ) : (
+            <IconStyles name='appbar_home_gray' extension='svg' />
+          )}
+          <TypographyStyles.Caption2>홈</TypographyStyles.Caption2>
+        </St.Menu>
+        <St.Menu>
+          {page === 'reserve' ? (
+            <IconStyles name='appbar_reserve' extension='svg' />
+          ) : (
+            <IconStyles name='appbar_reserve_gray' extension='svg' />
+          )}
+          <TypographyStyles.Caption2>일정관리</TypographyStyles.Caption2>
+        </St.Menu>
+        <St.Menu>
+          {page === 'member' ? (
+            <IconStyles name='appbar_patient' extension='svg' />
+          ) : (
+            <IconStyles name='appbar_patient_gray' extension='svg' />
+          )}
+
+          <TypographyStyles.Caption2>회원관리</TypographyStyles.Caption2>
+        </St.Menu>
+        <St.Menu>
+          {page === 'center' ? (
+            <IconStyles name='appbar_center' extension='svg' />
+          ) : (
+            <IconStyles name='appbar_center_gray' extension='svg' />
+          )}
+          <TypographyStyles.Caption2>센터관리</TypographyStyles.Caption2>
+        </St.Menu>
+        <St.Menu>
+          {page === 'mypage' ? (
+            <IconStyles name='appbar_mypage' extension='svg' />
+          ) : (
+            <IconStyles name='appbar_mypage_gray' extension='svg' />
+          )}
+          <TypographyStyles.Caption2>마이페이지</TypographyStyles.Caption2>
+        </St.Menu>
+      </St.MenuList>
+    </St.NavBottomContainer>
+  );
+};
+
+export default NavigationBarBottom;

--- a/src/lib/components/NavigationBar/Bottom/style.ts
+++ b/src/lib/components/NavigationBar/Bottom/style.ts
@@ -11,6 +11,7 @@ export const NavBottomContainer = styled.div`
   border-top: 1px solid var(--Line_200);
   background-color: white;
 
+  padding-bottom: 36px;
   // 임시 스타일
   margin-bottom: 10px;
 `;
@@ -23,7 +24,7 @@ export const MenuList = styled.div`
   justify-content: space-between;
 `;
 
-// 각 메뉴
+// 각
 export const Menu = styled.div`
   width: 56px;
 

--- a/src/lib/components/NavigationBar/Bottom/style.ts
+++ b/src/lib/components/NavigationBar/Bottom/style.ts
@@ -1,0 +1,35 @@
+import { styled } from 'styled-components';
+
+export const NavBottomContainer = styled.div`
+  height: 47px;
+  width: 1024px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-top: 1px solid var(--Line_200);
+  background-color: white;
+
+  // 임시 스타일
+  margin-bottom: 10px;
+`;
+
+// 메뉴 목록
+export const MenuList = styled.div`
+  width: 408px;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+// 각 메뉴
+export const Menu = styled.div`
+  width: 56px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  cursor: pointer;
+`;

--- a/src/lib/components/NavigationBar/Top/index.tsx
+++ b/src/lib/components/NavigationBar/Top/index.tsx
@@ -1,12 +1,12 @@
 import { GraphicStyles, TypographyStyles } from '@lib/foundation';
 import * as St from './style';
-import { INavTop } from './type';
+import { INavBar } from '../type';
 import Icon from '@lib/foundation/Icon';
 import { useState } from 'react';
 
-const NavigationBarTop = ({ page = 'home' }: INavTop) => {
+const NavigationBarTop = ({ page = 'home' }: INavBar) => {
   const centerList = ['직원 관리', '수강권 관리', '기록 관리', '미디어 관리', '운영 데이터', '알림메시지', '센터 정보'];
-  const mypage = ['내 정보', '공지사항', '앱 설정', '운영데이터'];
+  const mypageList = ['내 정보', '공지사항', '앱 설정', '운영데이터'];
   const memberName = '박관리자01';
 
   const [currentTab, setCurrentTab] = useState(0);
@@ -15,7 +15,6 @@ const NavigationBarTop = ({ page = 'home' }: INavTop) => {
     <St.NavTopContainer>
       <GraphicStyles name='logo' extension='svg' />
 
-      {/* 타이포그래피 바디3 세미볼드 적용시켜야 함 */}
       <TypographyStyles.Body3 as={'div'}>
         <St.ItemsList>
           {page === 'center' &&
@@ -25,7 +24,7 @@ const NavigationBarTop = ({ page = 'home' }: INavTop) => {
               </li>
             ))}
           {page === 'mypage' &&
-            mypage.map((item, index) => (
+            mypageList.map((item, index) => (
               <li key={item} onClick={() => setCurrentTab(index)} className={currentTab === index ? ' focused' : ''}>
                 {item}
               </li>

--- a/src/lib/components/NavigationBar/Top/index.tsx
+++ b/src/lib/components/NavigationBar/Top/index.tsx
@@ -2,33 +2,52 @@ import { GraphicStyles, TypographyStyles } from '@lib/foundation';
 import * as St from './style';
 import { INavTop } from './type';
 import Icon from '@lib/foundation/Icon';
+import { useState } from 'react';
 
 const NavigationBarTop = ({ page = 'home' }: INavTop) => {
   const centerList = ['직원 관리', '수강권 관리', '기록 관리', '미디어 관리', '운영 데이터', '알림메시지', '센터 정보'];
   const mypage = ['내 정보', '공지사항', '앱 설정', '운영데이터'];
   const memberName = '박관리자01';
+
+  const [currentTab, setCurrentTab] = useState(0);
+
   return (
     <St.NavTopContainer>
       <GraphicStyles name='logo' extension='svg' />
 
       {/* 타이포그래피 바디3 세미볼드 적용시켜야 함 */}
-      <St.ItemsList>
-        {page === 'center' && centerList.map((item) => <li>{item}</li>)}
-        {page === 'mypage' && mypage.map((item) => <li>{item}</li>)}
-      </St.ItemsList>
+      <TypographyStyles.Body3 as={'div'}>
+        <St.ItemsList>
+          {page === 'center' &&
+            centerList.map((item, index) => (
+              <li key={item} onClick={() => setCurrentTab(index)} className={currentTab === index ? ' focused' : ''}>
+                {item}
+              </li>
+            ))}
+          {page === 'mypage' &&
+            mypage.map((item, index) => (
+              <li key={item} onClick={() => setCurrentTab(index)} className={currentTab === index ? ' focused' : ''}>
+                {item}
+              </li>
+            ))}
+        </St.ItemsList>
+      </TypographyStyles.Body3>
 
-      <St.FixedItems>
-        <St.Line100 />
-        <St.UserInfo>
-          <GraphicStyles name='Profile_24px' extension='svg' />
-          <span>{memberName}</span>
-          <div>플랜 이용중</div>
-        </St.UserInfo>
-        <St.Line100 />
-        <St.IconWrapper>
-          <Icon name='notice' extension='svg' />
-        </St.IconWrapper>
-      </St.FixedItems>
+      <TypographyStyles.Body4 as={'div'}>
+        <St.FixedItems>
+          <St.Line100 />
+          <St.UserInfo>
+            <GraphicStyles name='Profile_24px' extension='svg' />
+            <span>{memberName}</span>
+            <div>플랜 이용중</div>
+          </St.UserInfo>
+          <St.Line100 />
+
+          <St.IconWrapper>
+            <Icon name='notice' extension='svg' />
+          </St.IconWrapper>
+        </St.FixedItems>
+      </TypographyStyles.Body4>
     </St.NavTopContainer>
   );
 };

--- a/src/lib/components/NavigationBar/Top/index.tsx
+++ b/src/lib/components/NavigationBar/Top/index.tsx
@@ -1,0 +1,35 @@
+import { GraphicStyles, TypographyStyles } from '@lib/foundation';
+import * as St from './style';
+import { INavTop } from './type';
+import Icon from '@lib/foundation/Icon';
+
+const NavigationBarTop = ({ page = 'home' }: INavTop) => {
+  const centerList = ['직원 관리', '수강권 관리', '기록 관리', '미디어 관리', '운영 데이터', '알림메시지', '센터 정보'];
+  const mypage = ['내 정보', '공지사항', '앱 설정', '운영데이터'];
+  const memberName = '박관리자01';
+  return (
+    <St.NavTopContainer>
+      <GraphicStyles name='logo' extension='svg' />
+
+      {/* 타이포그래피 바디3 세미볼드 적용시켜야 함 */}
+      <St.ItemsList>
+        {page === 'center' && centerList.map((item) => <li>{item}</li>)}
+        {page === 'mypage' && mypage.map((item) => <li>{item}</li>)}
+      </St.ItemsList>
+
+      <St.FixedItems>
+        <St.Line100 />
+        <St.UserInfo>
+          <GraphicStyles name='Profile_24px' extension='svg' />
+          <span>{memberName}</span>
+          <div>플랜 이용중</div>
+        </St.UserInfo>
+        <St.Line100 />
+        <St.IconWrapper>
+          <Icon name='notice' extension='svg' />
+        </St.IconWrapper>
+      </St.FixedItems>
+    </St.NavTopContainer>
+  );
+};
+export default NavigationBarTop;

--- a/src/lib/components/NavigationBar/Top/style.ts
+++ b/src/lib/components/NavigationBar/Top/style.ts
@@ -45,7 +45,10 @@ export const ItemsList = styled.ul`
 export const UserInfo = styled.div`
   display: flex;
   align-items: center;
+
   margin: 0 16px;
+
+  cursor: pointer;
 
   // 구독상태
   div {
@@ -65,6 +68,7 @@ export const UserInfo = styled.div`
   // 사용자 이름
   span {
     display: inline-block;
+
     margin: 0 8px;
   }
 `;
@@ -73,10 +77,14 @@ export const UserInfo = styled.div`
 export const Line100 = styled.div`
   height: 22px;
   width: 1px;
+
   background-color: var(--Line_200);
 `;
 
 // 아이콘 마진 설정
 export const IconWrapper = styled.div`
   margin-left: 12px;
+  img {
+    cursor: pointer;
+  }
 `;

--- a/src/lib/components/NavigationBar/Top/style.ts
+++ b/src/lib/components/NavigationBar/Top/style.ts
@@ -1,0 +1,67 @@
+import { styled } from 'styled-components';
+
+export const NavTopContainer = styled.div`
+  height: 50px;
+  width: 1024px;
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+
+  color: var(--Text_900);
+  // 임시설정
+  box-sizing: border-box;
+  background-color: white;
+  margin-bottom: 10px;
+
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+export const ItemsList = styled.ul`
+  display: flex;
+  li {
+    margin-left: 32px;
+    cursor: pointer;
+  }
+`;
+
+export const FixedItems = styled.div`
+  display: flex;
+  position: absolute;
+  right: 32px;
+`;
+export const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0 16px;
+
+  div {
+    width: 62px;
+    height: 21px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: 4px;
+    font-size: 10px;
+    color: var(--Pri_500);
+    background-color: var(--Bg_100);
+  }
+  span {
+    display: inline-block;
+    margin: 0 8px;
+  }
+`;
+
+export const Line100 = styled.div`
+  height: 22px;
+  width: 1px;
+  background-color: var(--Line_200);
+`;
+
+export const IconWrapper = styled.div`
+  margin-left: 12px;
+`;

--- a/src/lib/components/NavigationBar/Top/style.ts
+++ b/src/lib/components/NavigationBar/Top/style.ts
@@ -10,33 +10,44 @@ export const NavTopContainer = styled.div`
   padding: 0 24px;
 
   color: var(--Text_900);
-  // 임시설정
-  box-sizing: border-box;
+
   background-color: white;
+  box-sizing: border-box;
+  // 임시설정
   margin-bottom: 10px;
 
   font-size: 14px;
   font-weight: 500;
 `;
 
+// 로고 + 메뉴
+export const FixedItems = styled.div`
+  display: flex;
+
+  position: absolute;
+  right: 32px;
+  top: 50%;
+  transform: translate(0, -50%);
+`;
+
+// 메뉴 리스트
 export const ItemsList = styled.ul`
   display: flex;
   li {
     margin-left: 32px;
     cursor: pointer;
+    &.focused {
+      color: var(--Pri_500);
+    }
   }
 `;
 
-export const FixedItems = styled.div`
-  display: flex;
-  position: absolute;
-  right: 32px;
-`;
 export const UserInfo = styled.div`
   display: flex;
   align-items: center;
   margin: 0 16px;
 
+  // 구독상태
   div {
     width: 62px;
     height: 21px;
@@ -50,18 +61,22 @@ export const UserInfo = styled.div`
     color: var(--Pri_500);
     background-color: var(--Bg_100);
   }
+
+  // 사용자 이름
   span {
     display: inline-block;
     margin: 0 8px;
   }
 `;
 
+// 분류 선
 export const Line100 = styled.div`
   height: 22px;
   width: 1px;
   background-color: var(--Line_200);
 `;
 
+// 아이콘 마진 설정
 export const IconWrapper = styled.div`
   margin-left: 12px;
 `;

--- a/src/lib/components/NavigationBar/Top/type.ts
+++ b/src/lib/components/NavigationBar/Top/type.ts
@@ -1,0 +1,3 @@
+export interface INavTop {
+  page?: 'home' | 'reserve' | 'member' | 'center' | 'mypage';
+}

--- a/src/lib/components/NavigationBar/Top/type.ts
+++ b/src/lib/components/NavigationBar/Top/type.ts
@@ -1,3 +1,0 @@
-export interface INavTop {
-  page?: 'home' | 'reserve' | 'member' | 'center' | 'mypage';
-}

--- a/src/lib/components/NavigationBar/index.ts
+++ b/src/lib/components/NavigationBar/index.ts
@@ -1,0 +1,4 @@
+import NavigationBarBottom from './Bottom';
+import NavigationBarTop from './Top';
+
+export { NavigationBarBottom, NavigationBarTop };

--- a/src/lib/components/NavigationBar/type.ts
+++ b/src/lib/components/NavigationBar/type.ts
@@ -1,0 +1,3 @@
+export interface INavBar {
+  page?: 'home' | 'reserve' | 'member' | 'center' | 'mypage';
+}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- 어플 상단과 하단의 네비게이션 바를 컴포넌트화 하였습니다.

## 기대 결과

- 각 상태(home, reserve, member, center, mypage)에 따라 네비게이션을 설정할 수 있습니다.

## 리뷰어에게 전달 사항
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/4f8ba3a3-9c09-4b8d-ab91-4a60e0754dfa)
- NavgationBar - Top의 center와 mypage의 경우 메뉴 리스트 클릭 시 해당 메뉴가 파란 색으로 변경되도록 스타일 적용하였습니다. 이는 임시 사용 예제일 뿐 페이지 전환의 기능은 없습니다.
-  NavgationBar - Bottom은 page prop에 따라 변경됩니다.
- prop전달이 없을 시 기본값은 'home'으로 적용됩니다.

## 스크린샷
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/7eaa1c14-7cca-4160-a50d-f7a5d30633f1)

![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/c8a2b0e8-c3c9-4011-8243-9e776b6bd41d)


## 관련 이슈 번호

close : #32 
