### PR TITLE
feat: AppBar 개발 (#37)

### DIFF
--- a/src/lib/components/AppBar/index.tsx
+++ b/src/lib/components/AppBar/index.tsx
@@ -1,69 +1,60 @@
 import { IconStyles } from '@lib/foundation';
-import {
-  AppBarContainer,
-  DefalutLayout,
-  FixedItems,
-  FullPopupLayout,
-  IconBox,
-  IconBoxNomargin,
-  IconItems,
-  TextBox,
-} from './styles';
+import * as St from './styles';
 import { IAppBar } from './type';
 
 const AppBar = ({ pagename = '페이지네임', size = 'large', type }: IAppBar) => {
   return (
-    <AppBarContainer size={size}>
+    <St.AppBarContainer size={size}>
       {
         // full (페이지네임 + X 아이콘)
         size === 'full' ? (
-          <FullPopupLayout>
+          <St.FullPopupLayout>
             <div>{pagename}</div>
-            <IconBoxNomargin>
+            <St.IconBoxNomargin>
               <IconStyles name={'delete'} />
-            </IconBoxNomargin>
-          </FullPopupLayout>
+            </St.IconBoxNomargin>
+          </St.FullPopupLayout>
         ) : (
           // large or medium (<뒤로가기아이콘 + 페이지네임 + 아이콘||텍스트)
-          <DefalutLayout>
-            <FixedItems>
-              <IconBox>
+          <St.DefalutLayout>
+            <St.FixedItems>
+              <St.IconBox>
                 <IconStyles name={`back`} />
-              </IconBox>
+              </St.IconBox>
               <div>{pagename}</div>
-            </FixedItems>
+            </St.FixedItems>
 
             {type?.icon && (
-              <IconItems>
+              <St.IconItems>
                 {type?.icon.icon_L && (
-                  <IconBox>
+                  <St.IconBox>
                     <IconStyles name={`${type.icon?.icon_L}`} />
-                  </IconBox>
+                  </St.IconBox>
                 )}
                 {type.icon.icon_R && (
-                  <IconBoxNomargin>
+                  <St.IconBoxNomargin>
                     <IconStyles name={`${type.icon?.icon_R}`} />
-                  </IconBoxNomargin>
+                  </St.IconBoxNomargin>
                 )}
-              </IconItems>
+              </St.IconItems>
             )}
 
             {type?.text && (
-              <IconItems>
-                {type?.text.text_L && <TextBox>{type?.text?.text_L}</TextBox>}
-                {type?.text.text_R && <TextBox>{type?.text?.text_R}</TextBox>}
-              </IconItems>
+              <St.IconItems>
+                {type?.text.text_L && <St.TextBox>{type?.text?.text_L}</St.TextBox>}
+                {type?.text.text_R && <St.TextBox>{type?.text?.text_R}</St.TextBox>}
+              </St.IconItems>
             )}
 
             {type?.count && (
-              <TextBox>
+              <St.TextBox>
                 {type?.count.text}({type?.count.count})
-              </TextBox>
+              </St.TextBox>
             )}
-          </DefalutLayout>
+          </St.DefalutLayout>
         )
       }
-    </AppBarContainer>
+    </St.AppBarContainer>
   );
 };
 

--- a/src/lib/components/AppBar/index.tsx
+++ b/src/lib/components/AppBar/index.tsx
@@ -11,7 +11,7 @@ import {
 } from './styles';
 import { IAppBar } from './type';
 
-const AppBar = ({ pagename = '페이지네임', size, type }: IAppBar) => {
+const AppBar = ({ pagename = '페이지네임', size = 'large', type }: IAppBar) => {
   return (
     <AppBarContainer size={size}>
       {

--- a/src/lib/components/AppBar/index.tsx
+++ b/src/lib/components/AppBar/index.tsx
@@ -1,0 +1,70 @@
+import { IconStyles } from '@lib/foundation';
+import {
+  AppBarContainer,
+  DefalutLayout,
+  FixedItems,
+  FullPopupLayout,
+  IconBox,
+  IconBoxNomargin,
+  IconItems,
+  TextBox,
+} from './styles';
+import { IAppBar } from './type';
+
+const AppBar = ({ pagename = '페이지네임', size, type }: IAppBar) => {
+  return (
+    <AppBarContainer size={size}>
+      {
+        // full (페이지네임 + X 아이콘)
+        size === 'full' ? (
+          <FullPopupLayout>
+            <div>{pagename}</div>
+            <IconBoxNomargin>
+              <IconStyles name={'delete'} />
+            </IconBoxNomargin>
+          </FullPopupLayout>
+        ) : (
+          // large or medium (<뒤로가기아이콘 + 페이지네임 + 아이콘||텍스트)
+          <DefalutLayout>
+            <FixedItems>
+              <IconBox>
+                <IconStyles name={`back`} />
+              </IconBox>
+              <div>{pagename}</div>
+            </FixedItems>
+
+            {type?.icon && (
+              <IconItems>
+                {type?.icon.icon_L && (
+                  <IconBox>
+                    <IconStyles name={`${type.icon?.icon_L}`} />
+                  </IconBox>
+                )}
+                {type.icon.icon_R && (
+                  <IconBoxNomargin>
+                    <IconStyles name={`${type.icon?.icon_R}`} />
+                  </IconBoxNomargin>
+                )}
+              </IconItems>
+            )}
+
+            {type?.text && (
+              <IconItems>
+                {type?.text.text_L && <TextBox>{type?.text?.text_L}</TextBox>}
+                {type?.text.text_R && <TextBox>{type?.text?.text_R}</TextBox>}
+              </IconItems>
+            )}
+
+            {type?.count && (
+              <TextBox>
+                {type?.count.text}({type?.count.count})
+              </TextBox>
+            )}
+          </DefalutLayout>
+        )
+      }
+    </AppBarContainer>
+  );
+};
+
+export default AppBar;

--- a/src/lib/components/AppBar/styles.ts
+++ b/src/lib/components/AppBar/styles.ts
@@ -1,0 +1,82 @@
+import { styled } from 'styled-components';
+import { IAppBar } from './type';
+
+export const AppBarContainer = styled.div<IAppBar>`
+  width: ${(props) => (props.size === 'medium' ? '650px' : '1024px')};
+  height: ${(props) => (props.size === 'full' ? '56px' : '48px')};
+  box-sizing: border-box;
+
+  background-color: gray;
+
+  //임시스타일
+  margin-bottom: 10px;
+`;
+
+// 중간: 페이지네임 우:닫힘 의 레이아웃 (size: full)
+export const FullPopupLayout = styled.div<IAppBar>`
+  // 이게 안들어가면 오차가 생김... 추후에 다시 보기
+  height: 56px;
+  box-sizing: border-box;
+  //
+
+  padding: 16px 24px;
+  position: relative;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  :last-child {
+    position: absolute;
+    right: 24px;
+    transform: translate(50%, 0);
+  }
+`;
+
+// 좌:뒤로가기 우:버튼 의 레이아웃 (size: large, medium)
+export const DefalutLayout = styled.div<IAppBar>`
+  padding: 12px 16px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+// 아이콘 감싸는 박스
+export const IconBox = styled.div`
+  height: 24px;
+  width: 24px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin-right: 8px;
+
+  img {
+    cursor: pointer;
+  }
+`;
+
+// 아이콘 감싸는 박스 마진 없는 버전
+export const IconBoxNomargin = styled(IconBox)`
+  margin-right: 0px;
+`;
+
+// 텍스트 감싸는 박스
+export const TextBox = styled.div`
+  margin-left: 20px;
+  cursor: pointer;
+`;
+
+// 좌측 아이템 (뒤로가기아이콘, 페이지네임)
+export const FixedItems = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const IconItems = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/src/lib/components/AppBar/styles.ts
+++ b/src/lib/components/AppBar/styles.ts
@@ -6,7 +6,7 @@ export const AppBarContainer = styled.div<IAppBar>`
   height: ${(props) => (props.size === 'full' ? '56px' : '48px')};
   box-sizing: border-box;
 
-  background-color: gray;
+  background-color: white;
 
   //임시스타일
   margin-bottom: 10px;

--- a/src/lib/components/AppBar/type.ts
+++ b/src/lib/components/AppBar/type.ts
@@ -1,0 +1,30 @@
+import { IconName } from '@lib/foundation/Icon/type';
+
+export interface IAppBar {
+  size?: 'large' | 'medium' | 'full';
+  type?: {
+    icon?: { icon_L?: IconName; icon_R?: IconName };
+    text?: { text_L?: string; text_R?: string };
+    count?: { text?: string; count?: number };
+  };
+  pagename?: string;
+}
+
+// export interface IAppBar {
+//   type: IAppBarIcon | IAppBarText | IAppBarCount;
+//   pagename: string;
+// }
+
+// export interface IAppBarIcon {
+//   icon_L?: string;
+//   icon_R?: string;
+// }
+
+// export interface IAppBarText {
+//   text_L?: string;
+//   text_R?: string;
+// }
+
+// export interface IAppBarCount {
+//   count?: number;
+// }

--- a/src/lib/foundation/Icon/type.ts
+++ b/src/lib/foundation/Icon/type.ts
@@ -14,7 +14,7 @@ interface IIconGeneral {
 
 export type IIcon = IIconStrict | IIconGeneral;
 
-type IconName =
+export type IconName =
   | 'notice'
   | 'search'
   | 'close'


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- AppBar 컴포넌트를 만들었습니다.

## 기대 결과

- 원하는 유형의 AppBar를 생성할 수 있습니다.

## 리뷰어에게 전달 사항

- 모든 유형의 appbar를 하나의 타입으로 컨트롤 하고자 하다보니, 타입 중 icon | text | count 중 한 가지 상태만 설정되게 해야 하는데 아직은 그렇게 지정하지 못했습니다. 추후 리팩토링이 필요합니다.(^^;)
- **아이콘 2개를 쓰는 경우 (Appbar / Large / Icon / LR2)**
  - 아이콘은 타입이 지정되어 있어 자동완성이 됩니다.
  - 아이콘을 1개 쓰는 경우에는  icon_L 혹은 icon_R 하나만 사용하시면 됩니다.
```tsx
<AppBar
            size='large'
            pagename='페이지네임'
            type={{
              icon: { icon_L: 'add', icon_R: 'notice' },
            }}
          />
```
- **텍스트 1개를 쓰는 경우 (Appbar / Large / Text / LR2)**
  - 텍스트 2개를 쓰는 경우에는 text: { text_L: '버튼', text_R: '버튼' }와 같이 사용하면 됩니다.
```tsx
<AppBar
            size='large'
            pagename='페이지네임'
            type={{
              text: { text_R: '버튼' },
            }}
          />
```
- **파일 선택 시 카운트 되는 경우  (Appbar / Large / Count / LR1)**
```tsx
<AppBar size='large' pagename='페이지네임' type={{ count: { count: 5, text: '버튼' } }} />
```
- **문진 템플릿 생성 (Appbar / Medium / Text / LR1)**
  - size는 medium입니다. 
  - 전달하는 속성으로 text_R 혹은 text_L이 사용 가능합니다.
```tsx
<AppBar size='medium' pagename='문진 템플릿 생성' type={{ text: { text_R: '저장' } }} />
```
- **Full 팝업 (Appbar / Full / Text )**
  - size는 full입니다. 
  - 닫기 아이콘은 고정이므로 pagename외에 따로 전달할 prop은 없습니다.
```tsx
<AppBar size='full' pagename='페이지네임' />
```

_+) 성재님이 주신 review부분 수정했습니다!_

## 스크린샷
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/241fc650-bb78-4c4e-966f-e5ba0d741913)
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/c1c73db4-c6f9-4959-acdb-261c929da109)

## 관련 이슈 번호

close : #37 
