### PR TITLE
refactor: Foundation -Layout 스타일 수정 (#45)

### DIFF
--- a/src/lib/foundation/Layout/index.tsx
+++ b/src/lib/foundation/Layout/index.tsx
@@ -1,12 +1,9 @@
 import { ILayout } from './type';
 import { LayoutContainer } from './styles';
-import { useEffect, useState } from 'react';
 
 const Layout = ({ children, $size = 'tablet', $system = 'android' }: ILayout) => {
-  if ($system !== "android" && $system !== "ios")
-    throw new Error("$system 값에 오류가 있습니다");
-  if ($size !== "tablet" && $size !== "pc" && $size !== "phone")
-    throw new Error("$size 값에 오류가 있습니다");
+  if ($system !== 'android' && $system !== 'ios') throw new Error('$system 값에 오류가 있습니다');
+  if ($size !== 'tablet' && $size !== 'pc' && $size !== 'phone') throw new Error('$size 값에 오류가 있습니다');
 
   return (
     <LayoutContainer $size={$size} $system={$system}>

--- a/src/lib/foundation/Layout/index.tsx
+++ b/src/lib/foundation/Layout/index.tsx
@@ -1,9 +1,9 @@
 import { ILayout } from './type';
 import { LayoutContainer } from './styles';
 
-const Layout = ({ children, size = 'tablet', system = 'android' }: ILayout) => {
+const Layout = ({ children, $size = 'tablet', $system = 'android' }: ILayout) => {
   return (
-    <LayoutContainer size={size} system={system}>
+    <LayoutContainer $size={$size} $system={$system}>
       {children}
     </LayoutContainer>
   );

--- a/src/lib/foundation/Layout/index.tsx
+++ b/src/lib/foundation/Layout/index.tsx
@@ -1,7 +1,13 @@
 import { ILayout } from './type';
 import { LayoutContainer } from './styles';
+import { useEffect, useState } from 'react';
 
 const Layout = ({ children, $size = 'tablet', $system = 'android' }: ILayout) => {
+  if ($system !== "android" && $system !== "ios")
+    throw new Error("$system 값에 오류가 있습니다");
+  if ($size !== "tablet" && $size !== "pc" && $size !== "phone")
+    throw new Error("$size 값에 오류가 있습니다");
+
   return (
     <LayoutContainer $size={$size} $system={$system}>
       {children}

--- a/src/lib/foundation/Layout/styles.ts
+++ b/src/lib/foundation/Layout/styles.ts
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 import { ILayout } from './type';
 
 export const LayoutContainer = styled.div<ILayout>`
-  margin: 24px;
-  height: ${(props) => props.size === 'tablet' && '640px'};
-  width: ${(props) => props.size === 'tablet' && '1024px'};
+  padding: 2.4rem;
+  height: ${({ $size }) => $size === 'tablet' && '640px'};
+  width: ${({ $size }) => $size === 'tablet' && '1024px'};
 `;

--- a/src/lib/foundation/Layout/type.ts
+++ b/src/lib/foundation/Layout/type.ts
@@ -3,6 +3,6 @@ type TabletSize = 'tablet' | 'pc' | 'phone';
 
 export interface ILayout {
   children?: React.ReactNode;
-  system?: System;
-  size?: TabletSize;
+  $system?: System;
+  $size?: TabletSize;
 }


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 기능 추가
- [x] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- 기존에 개발한 코드에서 문제점을 찾아 수정했습니다.

## 기대 결과

- 스타일에만 영향을 주는 props(size, system) 는 실제 Dom 요소로 전달되지 않도록 함
```ts
$size={$size} $system={$system}
```
- 스타일 단위 px ⇒ rem으로 수정
- 기존의 `margin` 제거 후 좌우 `padding` 2.4rem 추가
- 에러 핸들링으로 에러 사항 나타냄

## 리뷰어에게 전달 사항

- 없음

## 스크린샷
- JS 에러핸들링 화면
![image](https://github.com/pie-sfac/3-14-ketotop/assets/102157884/1c61bc56-fa70-4ab1-a199-bb6904b04f56)

## 관련 이슈 번호

close : #45 
