### PR TITLE
refactor: Component - Dialog 버그 수정 및 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,27 @@
 // import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
+import { useState } from 'react';
 import { Fnd, Cmp } from './lib/index'; // For Testing Local Files
 
 function App() {
+  const [isOpenFirstDialog, setIsOpenFirstDialog] = useState(false);
   return (
     <>
       <Fnd.FoundationGlobalStyles />
-      <Fnd.LayoutStyles></Fnd.LayoutStyles>
+      <Fnd.LayoutStyles>
+        <h1>TS TEST</h1>
+        <button onClick={() => setIsOpenFirstDialog(true)}>open</button>
+        <Cmp.Dialog.Display
+          title='엄청나게 길이가 긴 텍스트여서 두 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요'
+          description={
+            '엄청나게 길이가 긴 텍스트여서 세 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요 아무런 의미없는 테스트 문구입니다 로렘 입섬은 아무런 의미없는 줄 글이다'
+          }
+          isOpen={isOpenFirstDialog}
+          onCloseEffect={() => setIsOpenFirstDialog(false)}
+        >
+          <Cmp.Dialog.GrayButton>Gray</Cmp.Dialog.GrayButton>
+          <Cmp.Dialog.PriButton>Pri</Cmp.Dialog.PriButton>
+        </Cmp.Dialog.Display>
+      </Fnd.LayoutStyles>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,11 @@
 // import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
-import { useState } from 'react';
 import { Fnd, Cmp } from './lib/index'; // For Testing Local Files
 
 function App() {
-  const [isOpenFirstDialog, setIsOpenFirstDialog] = useState(false);
   return (
     <>
       <Fnd.FoundationGlobalStyles />
-      <Fnd.LayoutStyles>
-        <h1>TS TEST</h1>
-        <button onClick={() => setIsOpenFirstDialog(true)}>open</button>
-        <Cmp.Dialog.Display
-          title='엄청나게 길이가 긴 텍스트여서 두 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요'
-          description={
-            '엄청나게 길이가 긴 텍스트여서 세 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요 아무런 의미없는 테스트 문구입니다 로렘 입섬은 아무런 의미없는 줄 글이다'
-          }
-          isOpen={isOpenFirstDialog}
-          onCloseEffect={() => setIsOpenFirstDialog(false)}
-        >
-          <Cmp.Dialog.GrayButton>Gray</Cmp.Dialog.GrayButton>
-          <Cmp.Dialog.PriButton>Pri</Cmp.Dialog.PriButton>
-        </Cmp.Dialog.Display>
-      </Fnd.LayoutStyles>
+      <Fnd.LayoutStyles></Fnd.LayoutStyles>
     </>
   );
 }

--- a/src/lib/components/Dialog/DialogButton/index.tsx
+++ b/src/lib/components/Dialog/DialogButton/index.tsx
@@ -1,0 +1,35 @@
+import * as St from './styles';
+import Button from '../../Button';
+import { Children } from './type';
+
+export const DialogButtonWrapper = ({ children }: Children) => {
+  return <St.DialogBtnWrapper>{children}</St.DialogBtnWrapper>;
+};
+
+/**
+ * @description 다이얼로그에 렌더되는 Gray버튼
+ * @type {children: string}
+ */
+export const GrayButton = ({ children, ...otherProps }: Children) => {
+  if (!children) throw new Error('Please enter DialogButton name!');
+
+  return (
+    <Button.Contained state='normal' size='medium' {...otherProps}>
+      {children}
+    </Button.Contained>
+  );
+};
+
+/**
+ * @description 다이얼로그에 렌더되는 Pri버튼
+ * @type {children: string}
+ */
+export const PriButton = ({ children, ...otherProps }: Children) => {
+  if (!children) throw new Error('Please enter DialogButton name!');
+
+  return (
+    <Button.Contained state='enabled' size='medium' {...otherProps}>
+      {children}
+    </Button.Contained>
+  );
+};

--- a/src/lib/components/Dialog/DialogButton/index.tsx
+++ b/src/lib/components/Dialog/DialogButton/index.tsx
@@ -1,8 +1,8 @@
 import * as St from './styles';
 import Button from '../../Button';
-import { Children } from './type';
+import { DialogButtonProps } from './type';
 
-export const DialogButtonWrapper = ({ children }: Children) => {
+export const DialogButtonWrapper = ({ children }: DialogButtonProps) => {
   return <St.DialogBtnWrapper>{children}</St.DialogBtnWrapper>;
 };
 
@@ -10,7 +10,7 @@ export const DialogButtonWrapper = ({ children }: Children) => {
  * @description 다이얼로그에 렌더되는 Gray버튼
  * @type {children: string}
  */
-export const GrayButton = ({ children, ...otherProps }: Children) => {
+export const GrayButton = ({ children, ...otherProps }: DialogButtonProps) => {
   if (!children) throw new Error('Please enter DialogButton name!');
 
   return (
@@ -24,7 +24,7 @@ export const GrayButton = ({ children, ...otherProps }: Children) => {
  * @description 다이얼로그에 렌더되는 Pri버튼
  * @type {children: string}
  */
-export const PriButton = ({ children, ...otherProps }: Children) => {
+export const PriButton = ({ children, ...otherProps }: DialogButtonProps) => {
   if (!children) throw new Error('Please enter DialogButton name!');
 
   return (

--- a/src/lib/components/Dialog/DialogButton/styles.ts
+++ b/src/lib/components/Dialog/DialogButton/styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const DialogBtnWrapper = styled.div`
+  margin-top: 2.8rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
+`;

--- a/src/lib/components/Dialog/DialogButton/type.ts
+++ b/src/lib/components/Dialog/DialogButton/type.ts
@@ -1,0 +1,6 @@
+export type Children = {
+  /**
+   * React의 JSX Element이거나 순수 문자열
+   */
+  children: React.ReactNode;
+};

--- a/src/lib/components/Dialog/DialogButton/type.ts
+++ b/src/lib/components/Dialog/DialogButton/type.ts
@@ -1,6 +1,3 @@
-export type Children = {
-  /**
-   * React의 JSX Element이거나 순수 문자열
-   */
-  children: React.ReactNode;
-};
+import { ButtonHTMLAttributes } from 'react';
+
+export type DialogButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;

--- a/src/lib/components/Dialog/index.tsx
+++ b/src/lib/components/Dialog/index.tsx
@@ -10,7 +10,7 @@ import { DialogButtonWrapper, PriButton, GrayButton } from './DialogButton';
  */
 export const Display: FC<DialogProps> = ({ title, description, onCloseEffect, isOpen, children: Buttons }) => {
   if (!title) throw new Error('Please enter DialogTitle!');
-  if (!onCloseEffect) throw new Error('Please enter onCloseEffect, with handling $isOpen state!');
+  if (!onCloseEffect) throw new Error('Please enter onCloseEffect, with handling isOpen state!');
 
   return (
     <>
@@ -22,7 +22,7 @@ export const Display: FC<DialogProps> = ({ title, description, onCloseEffect, is
             <DialogButtonWrapper>{Buttons}</DialogButtonWrapper>
           </St.Contents>
           <St.Icon onClick={onCloseEffect}>
-            <Icon name='close_24px' width={2.4} height={2.4} iconSize={1.6} />s
+            <Icon name='close_24px' $width={2.4} $height={2.4} $iconSize={2.4} />
           </St.Icon>
         </St.Dialog>
       )}

--- a/src/lib/components/Dialog/index.tsx
+++ b/src/lib/components/Dialog/index.tsx
@@ -1,52 +1,33 @@
 import Icon from '../../foundation/Icon';
 import * as St from './styles';
-import { TypographyStyles as Typo } from '../../foundation';
 import { DialogProps } from './type';
 import { FC } from 'react';
+import { DialogButtonWrapper, PriButton, GrayButton } from './DialogButton';
 
 /**
- * @description boolean 상태에 따라 렌더되는 Dialog 컴포넌트
- * @type {title: string; description: string, grayButtonName: string, priButtonName: string, onCloseEffect: () => void, onGrayEffect: () => void, onPriEffect: () => void, isOpen: boolean}
+ * @description $isOpen 상태에 따라 렌더되는 Dialog 컴포넌트
+ * @type {title: string, description?: string, onCloseEffect: () => void, isOpen: boolean, children: React.ReactNode}
  */
-export const Dialog: FC<DialogProps> = ({
-  title,
-  description,
-  grayButtonName,
-  priButtonName,
-  onCloseEffect,
-  onGrayEffect,
-  onPriEffect,
-  isOpen,
-}: DialogProps) => {
+export const Display: FC<DialogProps> = ({ title, description, onCloseEffect, isOpen, children: Buttons }) => {
+  if (!title) throw new Error('Please enter DialogTitle!');
+  if (!onCloseEffect) throw new Error('Please enter onCloseEffect, with handling $isOpen state!');
+
   return (
     <>
-      {isOpen ? (
+      {isOpen && (
         <St.Dialog>
-          <St.Icon onClick={onCloseEffect}>
-            <Icon name='close' width={16} height={16} />
-          </St.Icon>
           <St.Contents>
-            <St.TitleWrapper>
-              <Typo.Title6 title={title}>{title}</Typo.Title6>
-            </St.TitleWrapper>
-            {description ? (
-              <St.SubTextWrapper>
-                <Typo.Body4 title={description}>{description}</Typo.Body4>
-              </St.SubTextWrapper>
-            ) : null}
-            <St.BtnWrapper>
-              <St.GrayBtn marginNeed={priButtonName !== undefined} onClick={onGrayEffect}>
-                <Typo.Body4 as={'span'}>{grayButtonName}</Typo.Body4>
-              </St.GrayBtn>
-              {priButtonName ? (
-                <St.PriBtn onClick={onPriEffect}>
-                  <Typo.Body4 as={'span'}>{priButtonName}</Typo.Body4>
-                </St.PriBtn>
-              ) : null}
-            </St.BtnWrapper>
+            <St.TitleWrapper title={title}>{title}</St.TitleWrapper>
+            {description && <St.SubTextWrapper title={description}>{description}</St.SubTextWrapper>}
+            <DialogButtonWrapper>{Buttons}</DialogButtonWrapper>
           </St.Contents>
+          <St.Icon onClick={onCloseEffect}>
+            <Icon name='close_24px' width={2.4} height={2.4} iconSize={1.6} />s
+          </St.Icon>
         </St.Dialog>
-      ) : null}
+      )}
     </>
   );
 };
+
+export const Dialog = { Display, PriButton, GrayButton };

--- a/src/lib/components/Dialog/index.tsx
+++ b/src/lib/components/Dialog/index.tsx
@@ -8,7 +8,7 @@ import { DialogButtonWrapper, PriButton, GrayButton } from './DialogButton';
  * @description $isOpen 상태에 따라 렌더되는 Dialog 컴포넌트
  * @type {title: string, description?: string, onCloseEffect: () => void, isOpen: boolean, children: React.ReactNode}
  */
-export const Display: FC<DialogProps> = ({ title, description, onCloseEffect, isOpen, children: Buttons }) => {
+const Display: FC<DialogProps> = ({ title, description, onCloseEffect, isOpen, children: Buttons }) => {
   if (!title) throw new Error('Please enter DialogTitle!');
   if (!onCloseEffect) throw new Error('Please enter onCloseEffect, with handling isOpen state!');
 

--- a/src/lib/components/Dialog/styles.ts
+++ b/src/lib/components/Dialog/styles.ts
@@ -1,4 +1,5 @@
 import { styled, css } from 'styled-components';
+import { TypographyStyles as Typo } from '../../foundation';
 
 export const Dialog = styled.div`
   /* Layout */
@@ -17,8 +18,6 @@ export const Icon = styled.div`
   position: absolute;
   top: 1.6rem;
   right: 1.6rem;
-  width: 2.4rem;
-  height: 2.4rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -37,41 +36,15 @@ const Ellipsis = css`
   -webkit-box-orient: vertical;
 `;
 
-export const TitleWrapper = styled.div`
+export const TitleWrapper = styled(Typo.Title6)`
   margin-bottom: 0.8rem;
   /* Ellipsis */
   ${Ellipsis}
   -webkit-line-clamp: 2;
 `;
 
-export const SubTextWrapper = styled.div`
+export const SubTextWrapper = styled(Typo.Body4)`
   /* Ellipsis */
   ${Ellipsis}
   -webkit-line-clamp: 3;
-`;
-
-const BtnStyle = css`
-  padding: 0.8rem 1.2rem;
-  border-radius: 0.4rem;
-  /* TODO: reset CSS 수정 */
-  border: none;
-  width: 14.5rem;
-`;
-export const BtnWrapper = styled.div`
-  margin-top: 2.8rem;
-  display: flex;
-  justify-content: center;
-  gap: 0.8rem;
-`;
-
-export const GrayBtn = styled.button`
-  ${BtnStyle}
-  background-color: var(--Bg_100);
-  color: inherit;
-`;
-
-export const PriBtn = styled.button`
-  ${BtnStyle}
-  background-color: var(--Pri_500);
-  color: var(--Text_Wh);
 `;

--- a/src/lib/components/Dialog/styles.ts
+++ b/src/lib/components/Dialog/styles.ts
@@ -1,17 +1,13 @@
 import { styled, css } from 'styled-components';
 
 export const Dialog = styled.div`
-  /* TODO: must delete lined_reset css 적용 시 지울 라인들 */
-  color: black;
-  & p {
-    margin: 0;
-  }
   /* Layout */
-  width: 340px;
-  border-radius: 10px;
+  width: 34rem;
+  border-radius: 1rem;
   box-sizing: border-box;
-  border: 1px solid var(--Gray_300);
+  border: 0.1rem solid var(--Gray_300);
   background-color: var(--Bg_Wh);
+  padding: 4rem 2rem 1.6rem;
   /* Position */
   position: relative;
   text-align: center;
@@ -19,10 +15,10 @@ export const Dialog = styled.div`
 
 export const Icon = styled.div`
   position: absolute;
-  top: 16px;
-  right: 16px;
-  width: 24px;
-  height: 24px;
+  top: 1.6rem;
+  right: 1.6rem;
+  width: 2.4rem;
+  height: 2.4rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -30,7 +26,6 @@ export const Icon = styled.div`
 `;
 
 export const Contents = styled.div`
-  margin: 40px 20px 16px;
   color: var(--Text_900);
 `;
 
@@ -43,7 +38,7 @@ const Ellipsis = css`
 `;
 
 export const TitleWrapper = styled.div`
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
   /* Ellipsis */
   ${Ellipsis}
   -webkit-line-clamp: 2;
@@ -56,21 +51,23 @@ export const SubTextWrapper = styled.div`
 `;
 
 const BtnStyle = css`
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: 0.8rem 1.2rem;
+  border-radius: 0.4rem;
   /* TODO: reset CSS 수정 */
   border: none;
-  width: 145px;
+  width: 14.5rem;
 `;
 export const BtnWrapper = styled.div`
-  margin-top: 28px;
+  margin-top: 2.8rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.8rem;
 `;
 
-export const GrayBtn = styled.button<{ marginNeed: boolean }>`
+export const GrayBtn = styled.button`
   ${BtnStyle}
   background-color: var(--Bg_100);
   color: inherit;
-  margin-right: ${({ marginNeed }) => (marginNeed ? '8px' : '')};
 `;
 
 export const PriBtn = styled.button`

--- a/src/lib/components/Dialog/type.ts
+++ b/src/lib/components/Dialog/type.ts
@@ -8,27 +8,15 @@ export type DialogProps = {
    */
   description?: string;
   /**
-   * 그레이버튼에 렌더되는 텍스트
-   */
-  grayButtonName: string;
-  /**
-   * 프라이버튼에 렌더되는 텍스트, 필수 값 아님
-   */
-  priButtonName?: string;
-  /**
    * 닫기버튼을 누르면 실행될 Callback함수
    */
   onCloseEffect: () => void;
   /**
-   * 그레이버튼을 누르면 실행될 Callback함수
-   */
-  onGrayEffect: () => void;
-  /**
-   * 프라이버튼을 누르면 실행될 Callback함수
-   */
-  onPriEffect?: () => void;
-  /**
    * 해당 상태에 따라서 Dialog의 렌더 여부가 결정
    */
   isOpen: boolean;
+  /**
+   * 다이얼로그의 버튼 컴포넌트(Dialog.XxxButton)
+   */
+  children: React.ReactNode;
 };


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- 버그리포트에 있는 사항들을 수정하였습니다.

## 기대 결과

- 통일된 크기 단위, 에러처리, 사용자(프론트개발자)의 커스텀 이벤트 발생이 가능해집니다.

## 리뷰어에게 전달 사항

- 아래의 코드를 참고하세요
```js
// import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
import { useState } from 'react';
import { Fnd, Cmp } from './lib/index'; // For Testing Local Files

function App() {
  const [isOpenFirstDialog, setIsOpenFirstDialog] = useState(false);
  return (
    <>
      <Fnd.FoundationGlobalStyles />
      <Fnd.LayoutStyles>
        <h1>TS TEST</h1>
        <button onClick={() => setIsOpenFirstDialog(true)}>open</button>
        <Cmp.Dialog.Display
          title='엄청나게 길이가 긴 텍스트여서 두 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요'
          description={
            '엄청나게 길이가 긴 텍스트여서 세 줄로 말줄임이 되어야하는 제목입니다 잘 렌더되는지 테스트 해주세요 아무런 의미없는 테스트 문구입니다 로렘 입섬은 아무런 의미없는 줄 글이다'
          }
          isOpen={isOpenFirstDialog}
          onCloseEffect={() => setIsOpenFirstDialog(false)}
        >
          <Cmp.Dialog.GrayButton>Gray</Cmp.Dialog.GrayButton>
          <Cmp.Dialog.PriButton>Pri</Cmp.Dialog.PriButton>
        </Cmp.Dialog.Display>
      </Fnd.LayoutStyles>
    </>
  );
}

export default App;
```

## 스크린샷
<img width="334" alt="스크린샷 2023-08-07 오후 7 17 44" src="https://github.com/pie-sfac/3-14-ketotop/assets/48425930/414302fa-f813-4718-943d-9e5032de878b">

## 관련 이슈 번호

close : #52 
