### PR TITLE
[bug & refactor] Component - TextField 버그 및 리팩토링 (#64)

### DIFF
--- a/src/lib/components/TextField/index.tsx
+++ b/src/lib/components/TextField/index.tsx
@@ -16,6 +16,24 @@ export const TextField: FC<TextFieldType> = ({
   isSuccess = false,
   ...otherProps
 }) => {
+  if (!otherProps.id) {
+    // prettier-ignore
+    console.warn('Please enter id props in TextField. This improves usability and accessibility because it is associated with the label.');
+  }
+  if (inactiveMessage?.trim().length === 0) {
+    // prettier-ignore
+    throw new Error("If there's something you need to tell the user with inactiveMessage, enter a message with leading and trailing spaces removed");
+  }
+  if (errorMessage?.trim().length === 0) {
+    // prettier-ignore
+    throw new Error("If there's something you need to tell the user with errorMessage, enter a message with leading and trailing spaces removed");
+  }
+  if (successMessage?.trim().length === 0) {
+    // prettier-ignore
+    throw new Error("If there's something you need to tell the user with successMessage, enter a message with leading and trailing spaces removed");
+  }
+
+  console.log(inactiveMessage?.trim().length);
   return (
     <>
       <Typo.Body4 as={'label'} htmlFor={otherProps.id}>

--- a/src/lib/components/TextField/index.tsx
+++ b/src/lib/components/TextField/index.tsx
@@ -5,26 +5,25 @@ import { TextFieldType } from './type';
 
 /**
  * @description 원하는 상태의 메세지와 스타일이 렌더되는 TextField 컴포넌트
- * @type {id: string, label: string, message: string, errorMessage: string, successMessage: string, $error: boolean, $success: boolean}
+ * @type {id: string, labelText: string, message: string, errorMessage: string, successMessage: string, $error: boolean, $success: boolean}
  */
 export const TextField: FC<TextFieldType> = ({
-  id,
-  label,
-  message,
+  labelText,
+  inactiveMessage,
   errorMessage,
   successMessage,
-  $error = false,
-  $success = false,
+  isError = false,
+  isSuccess = false,
   ...otherProps
 }) => {
   return (
     <>
-      <Typo.Body4 as={'label'} htmlFor={label}>
-        {label}
+      <Typo.Body4 as={'label'} htmlFor={otherProps.id}>
+        {labelText}
       </Typo.Body4>
-      <St.TextField id={label} $error={$error} {...otherProps}></St.TextField>
-      <St.Message $error={$error} $success={$success}>
-        {$error ? errorMessage : $success ? successMessage : message}
+      <St.TextField $error={isError} {...otherProps}></St.TextField>
+      <St.Message $error={isError} $success={isSuccess}>
+        {isError ? errorMessage : isSuccess ? successMessage : inactiveMessage}
       </St.Message>
     </>
   );

--- a/src/lib/components/TextField/index.tsx
+++ b/src/lib/components/TextField/index.tsx
@@ -32,8 +32,6 @@ export const TextField: FC<TextFieldType> = ({
     // prettier-ignore
     throw new Error("If there's something you need to tell the user with successMessage, enter a message with leading and trailing spaces removed");
   }
-
-  console.log(inactiveMessage?.trim().length);
   return (
     <>
       <Typo.Body4 as={'label'} htmlFor={otherProps.id}>

--- a/src/lib/components/TextField/index.tsx
+++ b/src/lib/components/TextField/index.tsx
@@ -5,7 +5,7 @@ import { TextFieldType } from './type';
 
 /**
  * @description 원하는 상태의 메세지와 스타일이 렌더되는 TextField 컴포넌트
- * @type {id: string, labelText: string, message: string, errorMessage: string, successMessage: string, $error: boolean, $success: boolean}
+ * @type {labelText: string, inactiveMessage: string, errorMessage: string, successMessage: string, isError: boolean, isSuccess: boolean}
  */
 export const TextField: FC<TextFieldType> = ({
   labelText,

--- a/src/lib/components/TextField/index.tsx
+++ b/src/lib/components/TextField/index.tsx
@@ -1,4 +1,3 @@
-import { TypographyStyles as Typo } from '../../foundation';
 import * as St from './style';
 import { FC } from 'react';
 import { TextFieldType } from './type';
@@ -33,14 +32,14 @@ export const TextField: FC<TextFieldType> = ({
     throw new Error("If there's something you need to tell the user with successMessage, enter a message with leading and trailing spaces removed");
   }
   return (
-    <>
-      <Typo.Body4 as={'label'} htmlFor={otherProps.id}>
+    <St.Wrapper>
+      <St.Label as={'label'} htmlFor={otherProps.id}>
         {labelText}
-      </Typo.Body4>
+      </St.Label>
       <St.TextField $error={isError} {...otherProps}></St.TextField>
       <St.Message $error={isError} $success={isSuccess}>
         {isError ? errorMessage : isSuccess ? successMessage : inactiveMessage}
       </St.Message>
-    </>
+    </St.Wrapper>
   );
 };

--- a/src/lib/components/TextField/style.ts
+++ b/src/lib/components/TextField/style.ts
@@ -1,22 +1,24 @@
 import { TypographyStyles } from '../../foundation';
 import { styled } from 'styled-components';
-import { TextFieldType } from './type';
+import { StyledProps } from './type';
 
-interface CustomTextFieldProps extends Partial<TextFieldType> {
-  $error: boolean;
-}
+export const Wrapper = styled.div`
+  width: 36.4rem;
+`;
 
-export const TextField = styled.input<CustomTextFieldProps>`
-  /* TODO: reset적용시 삭제 */
-  margin: 0;
+export const Label = styled(TypographyStyles.Body4)`
+  display: inline-block;
+  margin-bottom: 0.8rem;
+`;
+
+export const TextField = styled.input<Partial<StyledProps>>`
   /* Layout */
   box-sizing: border-box;
-  width: 100%;
-  padding: 10px 16px;
-  margin-top: 8px;
+  padding: 1rem 1.6rem;
+  width: inherit;
   border-color: ${({ $error }) => ($error ? 'var(--System_Error)' : 'var(--Line_300)')};
-  border-width: 1px;
-  border-radius: 4px;
+  border-width: 0.1rem;
+  border-radius: 0.4rem;
   outline-style: none;
   outline: none;
   border-style: solid;
@@ -35,12 +37,12 @@ export const TextField = styled.input<CustomTextFieldProps>`
   &::placeholder {
     color: var(--Text_Hold);
     font-weight: 400;
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 144%;
   }
 `;
 
-export const Message = styled(TypographyStyles.Caption2)<{ $error: boolean; $success: boolean }>`
+export const Message = styled(TypographyStyles.Caption2)<StyledProps>`
   color: ${({ $error, $success }) =>
     $error ? 'var(--System_Error)' : $success ? 'var(--System_Positive)' : 'var(--Text_400)'};
   font-weight: 400;

--- a/src/lib/components/TextField/style.ts
+++ b/src/lib/components/TextField/style.ts
@@ -2,9 +2,11 @@ import { TypographyStyles } from '../../foundation';
 import { styled } from 'styled-components';
 import { TextFieldType } from './type';
 
-interface Temp extends Partial<TextFieldType> {}
+interface CustomTextFieldProps extends Partial<TextFieldType> {
+  $error: boolean;
+}
 
-export const TextField = styled.input<Temp>`
+export const TextField = styled.input<CustomTextFieldProps>`
   /* TODO: reset적용시 삭제 */
   margin: 0;
   /* Layout */

--- a/src/lib/components/TextField/type.ts
+++ b/src/lib/components/TextField/type.ts
@@ -4,11 +4,11 @@ export interface TextFieldType extends Partial<InputHTMLAttributes<HTMLInputElem
   /**
    * 입력받아야 할 TextField의 주제
    */
-  label: string;
+  labelText: string;
   /**
    * 그레이 색상으로 표시되는 inactived 메세지
    */
-  message?: string;
+  inactiveMessage?: string;
   /**
    * 레드 색상으로 표시되는 error 메세지, $error가 true이면 렌더된다
    */
@@ -20,9 +20,9 @@ export interface TextFieldType extends Partial<InputHTMLAttributes<HTMLInputElem
   /**
    * 에러여부, default: false, onBlur나 onChnage등의 이벤트 핸들러로 조작을 권고
    */
-  $error?: boolean;
+  isError?: boolean;
   /**
    * 성공여부, default: false, onBlur나 onChnage등의 이벤트 핸들러로 조작을 권고
    */
-  $success?: boolean;
+  isSuccess?: boolean;
 }

--- a/src/lib/components/TextField/type.ts
+++ b/src/lib/components/TextField/type.ts
@@ -26,3 +26,8 @@ export interface TextFieldType extends Partial<InputHTMLAttributes<HTMLInputElem
    */
   isSuccess?: boolean;
 }
+
+export interface StyledProps {
+  $error: boolean;
+  $success: boolean;
+}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 기능 추가
- [x] 스타일
- [x] 리팩토링
- [x] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- `Props` 관련 사항
  - 유저가 어색해할 수 있는 프리픽스를 스타일드 컴포넌트에만 전달하도록 변경
  - 부적절한 props 제거 (`id` => 이는 `input`태그의 기본적인 속성이므로 제거함)
  - 유효성 검사 추가(`id`가 없으면 워닝, 그외에 메세지 관련 검사를 추가하여 에러를 던짐)
- 스타일 관련 사항
  - 리셋과 중복되는 사항 제거
  - 너비 스타일을 피그마에 맞추어 `364px`로 맞춤
  - 단위를 `rem`으로 통합
- 이외의 사항
  - 스타일드 컴포넌트의 타입을 분리시킴

## 기대 결과

- 통일된 코드 스타일과 각 파일의 의미에 맞게 코드를 분리

## 리뷰어에게 전달 사항

- 개발담당자인 제가 찾아낸 요소들만을 수정한 버전입니다.
  - 개선사항이 더 보이신다면 의견부탁드립니다.
- 아래의 코드를 참고하시어 테스트 부탁드립니다.
  - `input`은 속성이 많아 유저(프론트개발자)에게 역할을 많이 주고있는 컴포넌트 입니다.
```js
// import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
import { useState } from 'react';
import { Fnd, Cmp } from './lib/index'; // For Testing Local Files

const validationSuccess = (str) => {
  return str.length > 10;
};
const validationErr = (str) => {
  return str.length <= 10;
};

function App() {
  const [value, setValue] = useState('');
  const [err, setErr] = useState(false);
  const [succ, setSucc] = useState(validationSuccess(value));

  return (
    <>
      <Fnd.FoundationGlobalStyles />
      <Fnd.LayoutStyles>
        <Cmp.TextField
          id='a'
          labelText='label'
          inactiveMessage='inactive message'
          errorMessage='red message'
          successMessage='green message'
          isSuccess={succ}
          isError={err}
          value={value}
          onChange={(e) => setValue(e.target.value)}
          onBlur={(e) => {
            setErr(validationErr(e.target.value));
            setSucc(validationSuccess(e.target.value));
          }}
        />
        <br />
        <h1 style={{ fontSize: '36px' }}>value : {value}</h1>
        <h1 style={{ fontSize: '36px' }}>value.length : {value.length}</h1>
      </Fnd.LayoutStyles>
    </>
  );
}

export default App;
```

## 스크린샷
<img width="396" alt="스크린샷 2023-08-08 오후 7 10 29" src="https://github.com/pie-sfac/3-14-ketotop/assets/48425930/ed65006f-101e-4a67-bc0f-c2cc1001e29b">

## 관련 이슈 번호

close : #64 
