### PR TITLE
[fix & refactor] Component - Dropdown 누락된 disabled 기능 추가

### DIFF
--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -5,9 +5,9 @@ import { DropdownProps } from './type';
 
 /**
  * @description 배열만을 values로 받는 기본형태의 Dropdown 컴포넌트
- * @type {items: string[], onChange: (string) => void, value: string, title: string, placeholder: string, width: string}
+ * @type {items: string[], onChange: (string) => void, value: string, title: string, placeholder: string, width: string, disabled: boolean}
  */
-export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, placeholder, width }) => {
+export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, placeholder, width, disabled }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const toggleValuesVisible = () => {
@@ -23,9 +23,23 @@ export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, pla
     <>
       <St.DropdownWrapper $width={width}>
         <St.DropdownLabel>{title}</St.DropdownLabel>
-        <St.DropdownButton as={'button'} onClick={toggleValuesVisible} $value={value} $isVisible={isVisible}>
+        <St.DropdownButton
+          as={'button'}
+          onClick={toggleValuesVisible}
+          $value={value}
+          $isVisible={isVisible}
+          disabled={disabled}
+        >
           <Fnd.TypographyStyles.Body4 as={'span'}>{value ? value : placeholder}</Fnd.TypographyStyles.Body4>
-          {!isVisible ? (
+          {disabled ? (
+            <Fnd.IconStyles
+              name='drop_more_gray_24px'
+              extension='svg'
+              $width={2.4}
+              $height={2.4}
+              $iconSize={2.4}
+            ></Fnd.IconStyles>
+          ) : !isVisible ? (
             <Fnd.IconStyles
               name='drop_more_24px'
               extension='svg'

--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -23,13 +23,27 @@ export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, pla
     <>
       <St.DropdownWrapper width={width}>
         <St.DropdownLabel>{title}</St.DropdownLabel>
-        <St.DropdownButton as={'button'} onClick={toggleValuesVisible} value={value} isVisible={isVisible}>
+        <St.DropdownButton as={'button'} onClick={toggleValuesVisible} $value={value} $isVisible={isVisible}>
           <Fnd.TypographyStyles.Body4 as={'span'}>{value ? value : placeholder}</Fnd.TypographyStyles.Body4>
-          <St.IconWrapper isVisible={isVisible}>
-            <Fnd.IconStyles name='drop_more' extension='svg' width={18} height={10}></Fnd.IconStyles>
-          </St.IconWrapper>
+          {!isVisible ? (
+            <Fnd.IconStyles
+              name='drop_more_24px'
+              extension='svg'
+              $width={2.4}
+              $height={2.4}
+              $iconSize={2.4}
+            ></Fnd.IconStyles>
+          ) : (
+            <Fnd.IconStyles
+              name='drop_less_24px'
+              extension='svg'
+              $width={2.4}
+              $height={2.4}
+              $iconSize={2.4}
+            ></Fnd.IconStyles>
+          )}
         </St.DropdownButton>
-        <St.DropdownValueWrapper isVisible={isVisible}>
+        <St.DropdownValueWrapper $isVisible={isVisible}>
           {items.map((item: string) => (
             <St.DropdownValue
               key={item}

--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -18,6 +18,7 @@ export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, pla
   if (!onChange) throw new Error('[Dropdown] onChange must be handled with a value');
   if (typeof onChange !== 'function') throw new Error('[Dropdown] onChange must be a function');
   if (!width) throw new Error('[Dropdown] Please enter at least one item');
+  if (placeholder.trim().length === 0) console.warn('[Dropdown] Forgot to enter a placeholder?');
 
   // Custom Func
   const toggleValuesVisible = () => {

--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -8,8 +8,18 @@ import { DropdownProps } from './type';
  * @type {items: string[], onChange: (string) => void, value: string, title: string, placeholder: string, width: string, disabled: boolean}
  */
 export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, placeholder, width, disabled }) => {
+  // Hooks
   const [isVisible, setIsVisible] = useState(false);
 
+  // Validation
+  if (!Array.isArray(items)) throw new Error('[Dropdown] items must be an array');
+  if (items.length === 0) throw new Error('[Dropdown] Please enter at least one item');
+  if (value === undefined) throw new Error('[Dropdown] value must be specified');
+  if (!onChange) throw new Error('[Dropdown] onChange must be handled with a value');
+  if (typeof onChange !== 'function') throw new Error('[Dropdown] onChange must be a function');
+  if (!width) throw new Error('[Dropdown] Please enter at least one item');
+
+  // Custom Func
   const toggleValuesVisible = () => {
     setIsVisible((prevVisibleState) => !prevVisibleState);
   };

--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -21,7 +21,7 @@ export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, pla
 
   return (
     <>
-      <St.DropdownWrapper width={width}>
+      <St.DropdownWrapper $width={width}>
         <St.DropdownLabel>{title}</St.DropdownLabel>
         <St.DropdownButton as={'button'} onClick={toggleValuesVisible} $value={value} $isVisible={isVisible}>
           <Fnd.TypographyStyles.Body4 as={'span'}>{value ? value : placeholder}</Fnd.TypographyStyles.Body4>

--- a/src/lib/components/Dropdown/General/index.tsx
+++ b/src/lib/components/Dropdown/General/index.tsx
@@ -58,9 +58,9 @@ export const Dropdown: FC<DropdownProps> = ({ items, onChange, value, title, pla
           )}
         </St.DropdownButton>
         <St.DropdownValueWrapper $isVisible={isVisible}>
-          {items.map((item: string) => (
+          {items.map((item: string, idx) => (
             <St.DropdownValue
-              key={item}
+              key={item + idx}
               as={'li'}
               onClick={() => onClickValue(item)}
               className={item === value ? 'selected' : ''}

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -49,6 +49,7 @@ export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`
 
   display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
   position: absolute;
+  z-index: 10;
 `;
 
 export const DropdownValue = styled(Fnd.TypographyStyles.Body4)`

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -20,12 +20,6 @@ export const DropdownButton = styled.button<{ $isVisible: boolean; $value: strin
   /* Reset Button CSS */
   padding: 1rem 1.6rem;
   background-color: var(--Bgc_Wh);
-  -webkit-font-smoothing: inherit;
-  -moz-osx-font-smoothing: inherit;
-  &::-moz-focus-inner {
-    border: 0;
-    padding: 0;
-  }
   /* Custom Desing from Figma */
   display: flex;
   justify-content: space-between;
@@ -44,7 +38,6 @@ export const DropdownButton = styled.button<{ $isVisible: boolean; $value: strin
 `;
 
 export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`
-  /* Reset */
   box-sizing: border-box;
   /* Custom Desing from Figma */
   width: 100%;

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -13,12 +13,12 @@ export const DropdownWrapper = styled.div<{ $width: string }>`
 
 export const DropdownLabel = styled(Fnd.TypographyStyles.Body4)`
   /* Custom Desing from Figma */
-  margin-bottom: 4px;
+  margin-bottom: 0.4rem;
 `;
 
 export const DropdownButton = styled.button<{ $isVisible: boolean; $value: string }>`
   /* Reset Button CSS */
-  padding: 10px 16px;
+  padding: 1rem 1.6rem;
   background-color: var(--Bgc_Wh);
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
@@ -30,9 +30,9 @@ export const DropdownButton = styled.button<{ $isVisible: boolean; $value: strin
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border: 1px solid ${({ $isVisible }) => ($isVisible ? 'var(--Pri_500)' : 'var(--Line_300)')};
-  border-radius: 4px;
-  border-radius: 10px;
+  border: 0.1rem solid ${({ $isVisible }) => ($isVisible ? 'var(--Pri_500)' : 'var(--Line_300)')};
+  border-radius: 0.4rem;
+  border-radius: 1rem;
   color: ${({ $value }) => ($value.length ? 'var(--Text_900)' : 'var(--Text_Hold)')};
   width: 100%;
   text-align: start;
@@ -48,10 +48,10 @@ export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`
   box-sizing: border-box;
   /* Custom Desing from Figma */
   width: 100%;
-  border: 1px solid var(--Line_300);
-  border-radius: 4px;
-  border-radius: 10px;
-  margin-top: 4px;
+  border: 0.1rem solid var(--Line_300);
+  border-radius: 0.4rem;
+  border-radius: 1rem;
+  margin-top: 0.4rem;
   overflow: hidden;
 
   display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
@@ -60,7 +60,7 @@ export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`
 
 export const DropdownValue = styled(Fnd.TypographyStyles.Body4)`
   /* Custom Desing from Figma */
-  padding: 12px 8px;
+  padding: 1.2rem 0.8rem;
   color: var(--Text_900);
   background-color: var(--Bg_Wh);
   /* Dynamic Background */

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -1,11 +1,11 @@
 import { styled } from 'styled-components';
 import { Fnd } from '../../..';
 
-export const DropdownWrapper = styled.div<{ width: string }>`
+export const DropdownWrapper = styled.div<{ $width: string }>`
   /* Custom Desing from Figma */
   position: relative;
   /* TODO: 너비지정을 어떻게할지 고민 */
-  width: ${({ width }) => width};
+  width: ${({ $width }) => $width};
   /* Reset */
   box-sizing: border-box;
   /* For Test */
@@ -18,9 +18,8 @@ export const DropdownLabel = styled(Fnd.TypographyStyles.Body4)`
 
 export const DropdownButton = styled.button<{ $isVisible: boolean; $value: string }>`
   /* Reset Button CSS */
-  border: none;
   padding: 10px 16px;
-  background: none;
+  background-color: var(--Bgc_Wh);
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
   &::-moz-focus-inner {

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -16,7 +16,7 @@ export const DropdownLabel = styled(Fnd.TypographyStyles.Body4)`
   margin-bottom: 4px;
 `;
 
-export const DropdownButton = styled.button<{ isVisible: boolean; value: string }>`
+export const DropdownButton = styled.button<{ $isVisible: boolean; $value: string }>`
   /* Reset Button CSS */
   border: none;
   padding: 10px 16px;
@@ -31,20 +31,15 @@ export const DropdownButton = styled.button<{ isVisible: boolean; value: string 
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border: 1px solid ${({ isVisible }) => (isVisible ? 'var(--Pri_500)' : 'var(--Line_300)')};
+  border: 1px solid ${({ $isVisible }) => ($isVisible ? 'var(--Pri_500)' : 'var(--Line_300)')};
   border-radius: 4px;
   border-radius: 10px;
-  color: ${({ value }) => (value.length ? 'var(--Text_900)' : 'var(--Text_Hold)')};
+  color: ${({ $value }) => ($value.length ? 'var(--Text_900)' : 'var(--Text_Hold)')};
   width: 100%;
   text-align: start;
 `;
-export const IconWrapper = styled.div<{ isVisible: boolean }>`
-  display: block;
-  transform: ${({ isVisible }) => (isVisible ? 'rotate(180deg)' : 'rotate(0)')};
-  /* TODO: animation 필요? */
-`;
 
-export const DropdownValueWrapper = styled.ul<{ isVisible: boolean }>`
+export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`
   /* Reset */
   box-sizing: border-box;
   /* Custom Desing from Figma */
@@ -55,7 +50,7 @@ export const DropdownValueWrapper = styled.ul<{ isVisible: boolean }>`
   margin-top: 4px;
   overflow: hidden;
 
-  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
+  display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
   position: absolute;
 `;
 

--- a/src/lib/components/Dropdown/General/styles.ts
+++ b/src/lib/components/Dropdown/General/styles.ts
@@ -36,6 +36,11 @@ export const DropdownButton = styled.button<{ $isVisible: boolean; $value: strin
   color: ${({ $value }) => ($value.length ? 'var(--Text_900)' : 'var(--Text_Hold)')};
   width: 100%;
   text-align: start;
+
+  &:disabled {
+    background-color: var(--Bg_100);
+    color: var(--Text_400);
+  }
 `;
 
 export const DropdownValueWrapper = styled.ul<{ $isVisible: boolean }>`

--- a/src/lib/components/Dropdown/General/type.ts
+++ b/src/lib/components/Dropdown/General/type.ts
@@ -23,4 +23,8 @@ export type DropdownProps = {
    * 컴포넌트의 너비, 필수값이므로 디자인 시안에 맞게 설정
    */
   width: string;
+  /**
+   * 드롭다운이 유저가 핸들링 가능한지 여부, 값에 따라 클릭가능여부와 배경색상등이 바뀐다
+   */
+  disabled?: boolean;
 };

--- a/src/lib/components/Dropdown/List/index.tsx
+++ b/src/lib/components/Dropdown/List/index.tsx
@@ -21,13 +21,19 @@ export const ListDropdown: FC<ListDropdownProps> = ({ category, items, value, on
 
   return (
     <St.ListDropdownWrapper>
-      <St.ContentWrapper as={'div'} value={value} width={width}>
+      <St.ContentWrapper as={'div'} $value={value} $width={width}>
         <h4>{category}</h4>
         <span>-</span>
         <St.SelectionWrapper>
           <St.DropdownButtonWrapper as={'button'} onClick={toggleValuesVisible}>
             <St.DropdownButtonText>{value.length ? value : '선택하세요'}</St.DropdownButtonText>
-            <Fnd.IconStyles name='more_small' extension='svg' width={24} height={24}></Fnd.IconStyles>
+            <Fnd.IconStyles
+              name='more_small_24px'
+              extension='svg'
+              $width={2.4}
+              $height={2.4}
+              $iconSize={2.4}
+            ></Fnd.IconStyles>
           </St.DropdownButtonWrapper>
           <St.ItemsWrapper $isVisible={isVisible}>
             {items.map((item: string) => (
@@ -44,7 +50,7 @@ export const ListDropdown: FC<ListDropdownProps> = ({ category, items, value, on
         </St.SelectionWrapper>
       </St.ContentWrapper>
       <St.CloseButtonWrapper onClick={() => onClose(value)}>
-        <Fnd.IconStyles name='close' extension='svg' width={16} height={16}></Fnd.IconStyles>
+        <Fnd.IconStyles name='close_24px' extension='svg' $width={2.4} $height={2.4} $iconSize={2.4}></Fnd.IconStyles>
       </St.CloseButtonWrapper>
     </St.ListDropdownWrapper>
   );

--- a/src/lib/components/Dropdown/List/index.tsx
+++ b/src/lib/components/Dropdown/List/index.tsx
@@ -8,8 +8,21 @@ import { ListDropdownProps } from './type';
  * @type {category: string, items: string[], value: string, onChange: (string) => void, onClose: () => void, width: string}
  */
 export const ListDropdown: FC<ListDropdownProps> = ({ category, items, value, onChange, onClose, width }) => {
+  // Hooks
   const [isVisible, setIsVisible] = useState(false);
 
+  // Validation
+  if (category.trim().length === 0) throw new Error('[ListDropdown] please enter category');
+  if (!Array.isArray(items)) throw new Error('[ListDropdown] items must be an array');
+  if (items.length === 0) throw new Error('[ListDropdown] Please enter at least one item');
+  if (value === undefined) throw new Error('[ListDropdown] value must be specified');
+  if (!onChange) throw new Error('[ListDropdown] onChange must be handled with a value');
+  if (typeof onChange !== 'function') throw new Error('[ListDropdown] onChange must be a function');
+  if (!onClose) throw new Error('[ListDropdown] onClose must be handled with a value');
+  if (typeof onClose !== 'function') throw new Error('[ListDropdown] onClose must be a function');
+  if (!width) throw new Error('[ListDropdown] Please enter at least one item');
+
+  // Custom Func
   const toggleValuesVisible = () => {
     setIsVisible((prevVisibleState) => !prevVisibleState);
   };

--- a/src/lib/components/Dropdown/List/index.tsx
+++ b/src/lib/components/Dropdown/List/index.tsx
@@ -27,13 +27,23 @@ export const ListDropdown: FC<ListDropdownProps> = ({ category, items, value, on
         <St.SelectionWrapper>
           <St.DropdownButtonWrapper as={'button'} onClick={toggleValuesVisible}>
             <St.DropdownButtonText>{value.length ? value : '선택하세요'}</St.DropdownButtonText>
-            <Fnd.IconStyles
-              name='more_small_24px'
-              extension='svg'
-              $width={2.4}
-              $height={2.4}
-              $iconSize={2.4}
-            ></Fnd.IconStyles>
+            {!isVisible ? (
+              <Fnd.IconStyles
+                name='more_small_24px'
+                extension='svg'
+                $width={2.4}
+                $height={2.4}
+                $iconSize={2.4}
+              ></Fnd.IconStyles>
+            ) : (
+              <Fnd.IconStyles
+                name='less_small_24px'
+                extension='svg'
+                $width={2.4}
+                $height={2.4}
+                $iconSize={2.4}
+              ></Fnd.IconStyles>
+            )}
           </St.DropdownButtonWrapper>
           <St.ItemsWrapper $isVisible={isVisible}>
             {items.map((item: string) => (

--- a/src/lib/components/Dropdown/List/index.tsx
+++ b/src/lib/components/Dropdown/List/index.tsx
@@ -46,10 +46,10 @@ export const ListDropdown: FC<ListDropdownProps> = ({ category, items, value, on
             )}
           </St.DropdownButtonWrapper>
           <St.ItemsWrapper $isVisible={isVisible}>
-            {items.map((item: string) => (
+            {items.map((item: string, idx) => (
               <St.Item
                 as={'li'}
-                key={item}
+                key={item + idx}
                 onClick={() => onClickValue(item)}
                 className={item === value ? 'selected' : ''}
               >

--- a/src/lib/components/Dropdown/List/styles.ts
+++ b/src/lib/components/Dropdown/List/styles.ts
@@ -4,20 +4,20 @@ import { Fnd } from '../../../';
 export const ListDropdownWrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
 `;
 
 export const ContentWrapper = styled(Fnd.TypographyStyles.Body2)<{ $value: string; $width: string }>`
   /* Width By props */
   width: ${({ $width }) => $width};
   box-sizing: border-box;
-  padding: 8px 22px;
+  padding: 0.8rem 2.2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-right: 4px;
-  border: 1px solid var(--Pri_200);
-  border-radius: 10px;
+  margin-right: 0.4rem;
+  border: 0.1rem solid var(--Pri_200);
+  border-radius: 1rem;
   /* Dynamic */
   background-color: ${({ $value }) => ($value.length ? 'var(--Bgc_50)' : 'var(--Bgc_Wh)')};
   color: ${({ $value }) => ($value.length ? 'var(--Pri_500)' : 'var(--Text_700)')};
@@ -48,27 +48,27 @@ export const DropdownButtonWrapper = styled(Fnd.TypographyStyles.Body2)`
 
 export const DropdownButtonText = styled.span`
   display: inline-block;
-  margin-right: 24px;
+  margin-right: 2.4rem;
 `;
 
 export const ItemsWrapper = styled.ul<{ $isVisible: boolean }>`
   /* Width By Figma */
-  width: 134px;
-  border-radius: 10px;
-  box-shadow: 0 0 8px 2px var(--Shadow);
+  width: 13.4rem;
+  border-radius: 1rem;
+  box-shadow: 0 0 0.8rem 0.2rem var(--Shadow);
   position: absolute;
   z-index: 10;
   left: 50%;
   transform: translateX(-50%);
   overflow: hidden;
   background-color: var(--Bg_Wh);
-  margin-top: 4px;
+  margin-top: 0.4rem;
   /* Dynamic */
   display: ${({ $isVisible }) => ($isVisible ? 'block' : 'none')};
 `;
 
 export const Item = styled(Fnd.TypographyStyles.Body4)`
-  padding: 8px 12px;
+  padding: 0.8rem 1.2rem;
   text-align: center;
   cursor: pointer;
   color: var(--Text_900);
@@ -83,8 +83,8 @@ export const Item = styled(Fnd.TypographyStyles.Body4)`
 
 export const CloseButtonWrapper = styled.div`
   cursor: pointer;
-  width: 24px;
-  height: 24px;
+  width: 2.4rem;
+  height: 2.4rem;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/lib/components/Dropdown/List/styles.ts
+++ b/src/lib/components/Dropdown/List/styles.ts
@@ -7,9 +7,9 @@ export const ListDropdownWrapper = styled.div`
   margin-bottom: 8px;
 `;
 
-export const ContentWrapper = styled(Fnd.TypographyStyles.Body2)<{ value: string; width: string }>`
+export const ContentWrapper = styled(Fnd.TypographyStyles.Body2)<{ $value: string; $width: string }>`
   /* Width By props */
-  width: ${({ width }) => width};
+  width: ${({ $width }) => $width};
   box-sizing: border-box;
   padding: 8px 22px;
   display: flex;
@@ -19,8 +19,8 @@ export const ContentWrapper = styled(Fnd.TypographyStyles.Body2)<{ value: string
   border: 1px solid var(--Pri_200);
   border-radius: 10px;
   /* Dynamic */
-  background-color: ${({ value }) => (value.length ? 'var(--Bgc_50)' : 'var(--Bgc_Wh)')};
-  color: ${({ value }) => (value.length ? 'var(--Pri_500)' : 'var(--Text_700)')};
+  background-color: ${({ $value }) => ($value.length ? 'var(--Bgc_50)' : 'var(--Bgc_Wh)')};
+  color: ${({ $value }) => ($value.length ? 'var(--Pri_500)' : 'var(--Text_700)')};
 `;
 
 export const SelectionWrapper = styled.div`


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- `General`한 `Dropdown`의 경우 유저의 행동을 막아야하는 `disabled` 상태와 그에 맞는 스타일이 필요함
- `Fnd.Icon` 수정에 따른 재정의
- `rem`으로 단위 통합
- `items`의 중복의 여지가 있는 `key`문제 해결
- 드롭다운 아이템들이 `z`축 뒤에 있어서 이상하게 렌더되는 현상 개선
- `Props` 검사에따른 적절한 조치가 없어 `JS`환경에서 이상하게 동작하는 현상 개선
- `DOM`으로 부적절한 `props`내리지 않기

## 기대 결과

- 일관된 코드스타일
- 알맞은 아이콘 사용
- 피그마 시안에 맞는 드롭다운 생성
- JS환경에서도 예상밖의 에러를 어느정도 방지

## 리뷰어에게 전달 사항

- 아래의 코드를 참고하시어 진행해주세요
```js
// import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
import { Fnd, Cmp } from './lib/index'; // For Testing Local Files
import { useState } from 'react';

const items = Array(5)
  .fill('')
  .map((_, i) => `${i + 1}번째 아이템`);

const subCategory = {
  '오른쪽 팔': Array(6)
    .fill('')
    .map((_, idx) => `통증부위 ${idx + 1}`),
  '오른쪽 다리': Array(6)
    .fill('')
    .map((_, idx) => `통증부위 ${idx + 1}`),
};

function App() {
  const [value, setValue] = useState('');
  const [selectedValues, setSelectedValues] = useState([{ mainCategory: '오른쪽 팔', value: '' }]);
  const addPain = () => {
    setSelectedValues((prev) => {
      return [...prev, { mainCategory: '오른쪽 팔', value: '' }];
    });
  };
  const onSelect = (idx, selected) => {
    setSelectedValues((prev) => {
      const copyOfSelected = prev.slice();
      const selectedObj = prev[idx];
      selectedObj.value = selected;
      copyOfSelected[idx] = selectedObj;
      return copyOfSelected;
    });
  };

  const onClose = (idx, selected) => {
    setSelectedValues((prev) => {
      const copyOfFiltered = prev.filter((val, i) => val.value !== selected || i !== idx);
      return copyOfFiltered;
    });
  };
  return (
    <>
      <Fnd.FoundationGlobalStyles />
      <Fnd.LayoutStyles>
        <Cmp.Dropdown
          title={'타이틀'}
          placeholder={'플레이스 홀더'}
          value={value}
          items={items}
          onChange={(selected) => setValue(selected)}
          width='36.4rem'
          disabled={false}
        ></Cmp.Dropdown>
        <p>드롭다운이 되면 아래의 요소들이 밀리는지 시험해보기 위한 문구</p>
        <button onClick={addPain}>add pain area</button>
        <section style={{ width: '500px', border: '1px solid black' }}>
          {selectedValues.map((val, idx) => (
            <Cmp.ListDropdown
              key={val.value + val.mainCategory + idx}
              category={val.mainCategory}
              items={subCategory[val.mainCategory]}
              value={val.value}
              onChange={(selected) => onSelect(idx, selected)}
              onClose={(selected) => onClose(idx, selected)}
              width={'313px'}
            ></Cmp.ListDropdown>
          ))}
          <Cmp.ListDropdown
            category='custom'
            items={['aaa']}
            value=''
            onChange={(v) => console.log('change', v)}
            onClose={(v) => console.log('close', v)}
            width='31.3rem'
          ></Cmp.ListDropdown>
        </section>
      </Fnd.LayoutStyles>
    </>
  );
}

export default App;
```

## 스크린
<img width="359" alt="스크린샷 2023-08-09 오후 8 29 05" src="https://github.com/pie-sfac/3-14-ketotop/assets/48425930/d4a8ac89-49cb-497b-9bd1-228507b51269">
샷
<img width="348" alt="스크린샷 2023-08-09 오후 8 29 27" src="https://github.com/pie-sfac/3-14-ketotop/assets/48425930/e36fd1fa-0686-40f6-84aa-efcf972f724c">



## 관련 이슈 번호

close : #44 
