### PR TITLE
refactor: Tabs 컴포넌트 버그 수정 및 리팩토링 작업

### DIFF
--- a/src/lib/components/Tabs/TabComponent/index.tsx
+++ b/src/lib/components/Tabs/TabComponent/index.tsx
@@ -3,11 +3,11 @@ import { TabComponentProps } from './type';
 import * as St from './styles';
 import { Fnd } from '../../../';
 
-const TabComponent: FC<TabComponentProps> = ({ instance, children, isVisible = false }) => {
+const TabComponent: FC<TabComponentProps> = ({ instance, children, isVisible = false, onClick }) => {
   if (!isVisible) return null;
 
   return (
-    <St.TabComponentWrapper instance={instance}>
+    <St.TabComponentWrapper $instance={instance} onClick={onClick}>
       {instance === 'Select' ? (
         <Fnd.TypographyStyles.Body2>{children}</Fnd.TypographyStyles.Body2>
       ) : (

--- a/src/lib/components/Tabs/TabComponent/styles.ts
+++ b/src/lib/components/Tabs/TabComponent/styles.ts
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 
-export const TabComponentWrapper = styled.div<{ instance: 'Select' | 'Unselect' }>`
+export const TabComponentWrapper = styled.div<{ $instance: 'Select' | 'Unselect' }>`
   display: inline-flex;
-  padding: ${(props) => (props.instance === 'Select' ? '8px 12px 6px' : '8px 12px 7px')};
+  padding: ${(props) => (props.$instance === 'Select' ? '8px 12px 6px' : '8px 12px 7px')};
   justify-content: center;
   align-items: center;
   gap: 10px;
-  color: ${(props) => (props.instance === 'Select' ? 'var(--Pri_300)' : 'var(--Line_300)')};
-  border-bottom: ${(props) => (props.instance === 'Select' ? '2px solid var(--Pri_300)' : '1px solid var(--Line_300)')};
+  color: ${(props) => (props.$instance === 'Select' ? 'var(--Pri_300)' : 'var(--Line_300)')};
+  border-bottom: ${(props) =>
+    props.$instance === 'Select' ? '2px solid var(--Pri_300)' : '1px solid var(--Line_300)'};
   cursor: pointer;
 `;

--- a/src/lib/components/Tabs/TabComponent/styles.ts
+++ b/src/lib/components/Tabs/TabComponent/styles.ts
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 
 export const TabComponentWrapper = styled.div<{ $instance: 'Select' | 'Unselect' }>`
   display: inline-flex;
-  padding: ${(props) => (props.$instance === 'Select' ? '8px 12px 6px' : '8px 12px 7px')};
+  padding: ${(props) => (props.$instance === 'Select' ? '0.8rem 1.2rem 0.6rem' : '0.8rem 1.2rem 0.7rem')};
   justify-content: center;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
   color: ${(props) => (props.$instance === 'Select' ? 'var(--Pri_300)' : 'var(--Line_300)')};
   border-bottom: ${(props) =>
-    props.$instance === 'Select' ? '2px solid var(--Pri_300)' : '1px solid var(--Line_300)'};
+    props.$instance === 'Select' ? '0.2rem solid var(--Pri_300)' : '0.1rem solid var(--Line_300)'};
   cursor: pointer;
 `;

--- a/src/lib/components/Tabs/TabComponent/type.ts
+++ b/src/lib/components/Tabs/TabComponent/type.ts
@@ -2,4 +2,5 @@ export interface TabComponentProps {
   instance: 'Select' | 'Unselect';
   children?: React.ReactNode;
   isVisible: boolean;
+  onClick: () => void;
 }

--- a/src/lib/components/Tabs/index.tsx
+++ b/src/lib/components/Tabs/index.tsx
@@ -3,11 +3,6 @@ import { TabListProps } from './type';
 import TabComponent from './TabComponent';
 import * as St from './styles';
 
-/** 사용법
- * tapList: 탭메뉴 리스트 ( string[] )
- * selected: 선택된 탭메뉴 인덱스 ( number )
- * showMenuIdx: 보여질 탭메뉴 인덱스 리스트 ( number[] )
- */
 /**
  * @description - Tab 스타일
  * @params
@@ -16,13 +11,18 @@ import * as St from './styles';
  * {number} selected 선택된 탭메뉴 인덱스
  * @params
  * {number[]} showMenuIdx 보여질 탭메뉴 인덱스 리스트
+ * @params
+ * {(index: number) => void} onTabClick 탭메뉴(index) 클릭 시 수행할 동작
  */
 
-const Tabs: FC<TabListProps> = ({ tapList, selected, showMenuIdx }) => {
+const Tabs: FC<TabListProps> = ({ tapList, selected, showMenuIdx, onTabClick }) => {
+  if (!tapList || tapList.length === 0) {
+    throw new Error('탭메뉴 리스트는 배열 안에 하나 이상 있어야 합니다.');
+  }
   if (tapList.length > 10) {
     throw new Error('10개 이상의 탭메뉴를 포함할 수 없습니다..');
   }
-  if (selected > tapList.length - 1) {
+  if (selected > tapList.length - 1 || selected < 0) {
     throw new Error('선택된 탭메뉴가 존재하지 않습니다.');
   }
   return (
@@ -32,7 +32,7 @@ const Tabs: FC<TabListProps> = ({ tapList, selected, showMenuIdx }) => {
         const instanceType = selected === index ? 'Select' : 'Unselect';
 
         return (
-          <TabComponent key={index} instance={instanceType} isVisible={isVisible}>
+          <TabComponent key={index} instance={instanceType} isVisible={isVisible} onClick={() => onTabClick(index)}>
             {item}
           </TabComponent>
         );

--- a/src/lib/components/Tabs/styles.ts
+++ b/src/lib/components/Tabs/styles.ts
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 
 export const TabWrapper = styled.section`
   display: flex;
-  width: 1245px;
-  padding-left: 20px;
-  padding-top: 20px;
-  padding-bottom: 28px;
+  width: 100%;
+  box-sizing: border-box;
+  padding-left: 2rem;
+  padding-top: 2rem;
+  padding-bottom: 2.8rem;
 
   // 스크롤바 숨기기
   overflow-x: auto;

--- a/src/lib/components/Tabs/type.ts
+++ b/src/lib/components/Tabs/type.ts
@@ -2,4 +2,5 @@ export interface TabListProps {
   tapList: (string | undefined)[];
   selected: number;
   showMenuIdx: number[];
+  onTabClick: (idx: number) => void;
 }


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 기능 추가
- [ ] 스타일
- [x] 리팩토링
- [x] 문서 수정
- [x] 버그 수정
- [ ] 기타

## 왜 코드를 추가/변경하였나요?

- 이슈에 적힌 수정사항을 수정하기위해 코드를 변경 및 추가 하였습니다.

## 기대 결과

- onClick 이벤트 관한 props 를 추가 하였습니다. ( Tabs 특성상 페이지네이션 정도의 기능만 필요하다고 판단하여 그렇게 했습니다. )

## 리뷰어에게 전달 사항
```jsx
// import { Fnd, Cmp } from 'pds-3-14'; // For Testing NPM package
import { Fnd, Cmp } from './lib/index'; // For Testing Local Files
import { useState } from 'react';

function App() {
  const tapList = ['Home', 'Profile', 'Settings'];
  const showMenuIdx = [0, 1, 2];
  const [selected, setSelected] = useState(0);
  const handleTabClick = (index: number) => {
    // index에 따라 특정 로직 수행
    switch (index) {
      case 0:
        // Home 탭 클릭 시 수행할 동작
        setSelected(index);
        break;
      case 1:
        // Profile 탭 클릭 시 수행할 동작
        setSelected(index);
        break;
      case 2:
        // Settings 탭 클릭 시 수행할 동작
        setSelected(index);
        break;
      default:
        break;
    }
  };
  return (
    <>
      <Fnd.FoundationGlobalStyles />
      <Fnd.LayoutStyles>
        <Cmp.Tabs
          tapList={tapList}
          selected={selected}
          showMenuIdx={showMenuIdx}
          onTabClick={handleTabClick} // 이벤트 핸들러 전달
        />
      </Fnd.LayoutStyles>
    </>
  );
}

export default App;

```
- click 이벤트의 index 는 탭의 index 입니다.

## 스크린샷

![tabs_AdobeExpress](https://github.com/pie-sfac/3-14-ketotop/assets/57481378/f8b97fae-551a-4de7-98ec-5e9e69153d00)
<img width="1065" alt="레이아웃에 맞게" src="https://github.com/pie-sfac/3-14-ketotop/assets/57481378/c95b5bdd-1a74-4fff-a069-fb063faf2e22">
(레이아웃에 맞도록 수정)

## 관련 이슈 번호

close : #78 
